### PR TITLE
Plumb context through Loom's network-touching methods

### DIFF
--- a/exp/loom/loom.go
+++ b/exp/loom/loom.go
@@ -38,7 +38,7 @@ func New(serviceName string, useAgent bool) (*Loom, error) {
 	}, nil
 }
 
-func (l *Loom) client() (*ssh.Client, error) {
+func (l *Loom) client(ctx context.Context) (*ssh.Client, error) {
 	var client *ssh.Client
 	var err error
 	port := 22
@@ -49,10 +49,7 @@ func (l *Loom) client() (*ssh.Client, error) {
 		}
 	}
 	if l.useAgent {
-		// TODO: Loom's public API does not yet take a context.Context. Until
-		// it does, the agent-socket dial uses an unbounded background ctx and
-		// relies on ClientConfig.Timeout below to bound the SSH dial itself.
-		client, err = ssh.NewWithAgentContext(context.Background(), l.hostname, port, l.login, false)
+		client, err = ssh.NewWithAgentContext(ctx, l.hostname, port, l.login, false)
 		if err != nil {
 			return nil, err
 		}
@@ -67,8 +64,8 @@ func (l *Loom) client() (*ssh.Client, error) {
 	return client, nil
 }
 
-func (l *Loom) Remote(command string) error {
-	client, err := l.client()
+func (l *Loom) Remote(ctx context.Context, command string) error {
+	client, err := l.client(ctx)
 	if err != nil {
 		return err
 	}
@@ -77,17 +74,17 @@ func (l *Loom) Remote(command string) error {
 	})
 }
 
-func (l *Loom) Upload(src, dst string) error {
-	client, err := l.client()
+func (l *Loom) Upload(ctx context.Context, src, dst string) error {
+	client, err := l.client(ctx)
 	if err != nil {
 		return err
 	}
 	return client.Upload(src, dst, "0755", false)
 }
 
-func (l *Loom) Service(command string) error {
+func (l *Loom) Service(ctx context.Context, command string) error {
 	cmd := fmt.Sprintf("sudo systemctl %s %s", command, l.serviceName)
-	return l.Remote(cmd)
+	return l.Remote(ctx, cmd)
 }
 
 func (l *Loom) ServiceFile(execStart string) (string, error) {
@@ -99,34 +96,34 @@ func (l *Loom) ServiceFile(execStart string) (string, error) {
 	return filename, nil
 }
 
-func (l *Loom) UploadToDestination(filename string) error {
+func (l *Loom) UploadToDestination(ctx context.Context, filename string) error {
 	source := fmt.Sprintf("./%s", filename)
 	destination := fmt.Sprintf("%s/%s", l.destination, filename)
-	return l.Upload(source, destination)
+	return l.Upload(ctx, source, destination)
 }
 
-func (l *Loom) MoveToOptBin() error {
+func (l *Loom) MoveToOptBin(ctx context.Context) error {
 	cmd := fmt.Sprintf("sudo mv -f %s /opt/%s/bin/%s", l.serviceName, l.serviceName, l.serviceName)
-	return l.Remote(cmd)
+	return l.Remote(ctx, cmd)
 }
 
-func (l *Loom) Setup(serviceFile string) error {
-	if err := l.UploadToDestination(serviceFile); err != nil {
+func (l *Loom) Setup(ctx context.Context, serviceFile string) error {
+	if err := l.UploadToDestination(ctx, serviceFile); err != nil {
 		return err
 	}
 	cmd := fmt.Sprintf("sudo mv -f %s/%s /etc/systemd/system/%s", l.destination, serviceFile, serviceFile)
-	if err := l.Remote(cmd); err != nil {
+	if err := l.Remote(ctx, cmd); err != nil {
 		return err
 	}
 	cmd = fmt.Sprintf("sudo mkdir -p /opt/%s/{bin,etc,log}", l.serviceName)
-	if err := l.Remote(cmd); err != nil {
+	if err := l.Remote(ctx, cmd); err != nil {
 		return err
 	}
-	if err := l.UploadToDestination(l.serviceName); err != nil {
+	if err := l.UploadToDestination(ctx, l.serviceName); err != nil {
 		return err
 	}
-	if err := l.MoveToOptBin(); err != nil {
+	if err := l.MoveToOptBin(ctx); err != nil {
 		return err
 	}
-	return l.Service("enable")
+	return l.Service(ctx, "enable")
 }

--- a/exp/loom/loom_test.go
+++ b/exp/loom/loom_test.go
@@ -146,7 +146,7 @@ func TestLoom_client(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := tt.loom.client()
+			_, err := tt.loom.client(t.Context())
 			if (err != nil) != tt.expectError {
 				t.Errorf("client() error = %v, expectError %v", err, tt.expectError)
 			}
@@ -227,7 +227,7 @@ func TestLoom_UploadToDestination(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.loom.UploadToDestination(tt.filename)
+			err := tt.loom.UploadToDestination(t.Context(), tt.filename)
 			if (err != nil) != tt.expectError {
 				t.Errorf("UploadToDestination() error = %v, expectError %v", err, tt.expectError)
 			}
@@ -244,7 +244,7 @@ func TestLoom_Remote(t *testing.T) {
 		useAgent: false,
 	}
 
-	err := loom.Remote("echo 'test'")
+	err := loom.Remote(t.Context(), "echo 'test'")
 	if err == nil {
 		t.Error("Remote() expected error for nonexistent host, got nil")
 	}
@@ -259,7 +259,7 @@ func TestLoom_Upload(t *testing.T) {
 		useAgent: false,
 	}
 
-	err := loom.Upload("test.txt", "/tmp/test.txt")
+	err := loom.Upload(t.Context(), "test.txt", "/tmp/test.txt")
 	if err == nil {
 		t.Error("Upload() expected error for nonexistent host, got nil")
 	}
@@ -275,7 +275,7 @@ func TestLoom_Service(t *testing.T) {
 		serviceName: "test-service",
 	}
 
-	err := loom.Service("start")
+	err := loom.Service(t.Context(), "start")
 	if err == nil {
 		t.Error("Service() expected error for nonexistent host, got nil")
 	}
@@ -291,7 +291,7 @@ func TestLoom_MoveToOptBin(t *testing.T) {
 		serviceName: "test-service",
 	}
 
-	err := loom.MoveToOptBin()
+	err := loom.MoveToOptBin(t.Context())
 	if err == nil {
 		t.Error("MoveToOptBin() expected error for nonexistent host, got nil")
 	}
@@ -308,7 +308,7 @@ func TestLoom_Setup(t *testing.T) {
 		destination: "/tmp/test",
 	}
 
-	err := loom.Setup("test-service.service")
+	err := loom.Setup(t.Context(), "test-service.service")
 	if err == nil {
 		t.Error("Setup() expected error for nonexistent host, got nil")
 	}


### PR DESCRIPTION
## Summary

Removes the \`context.Background()\` TODO in \`exp/loom/loom.client()\` by adding \`ctx context.Context\` as the first parameter on every Loom method that touches the network.

## What changed

\`exp/loom\` is in the experimental tree and carries no API stability promise, so signatures change directly instead of doubling the surface with deprecated wrappers.

Methods now taking \`ctx\` as the first parameter:
- \`Loom.client\`
- \`Loom.Remote\`
- \`Loom.Upload\`
- \`Loom.Service\`
- \`Loom.UploadToDestination\`
- \`Loom.MoveToOptBin\`
- \`Loom.Setup\`

\`Loom.client\` now hands the caller's \`ctx\` straight to \`ssh.NewWithAgentContext\`, replacing the \`context.Background()\` TODO. The agent-socket dial and the SSH dial (still bounded by \`ClientConfig.Timeout\`) both honor caller-supplied deadlines / cancellation.

\`Loom.New\` and \`Loom.ServiceFile\` stay context-less — they only do local file work.

Tests updated to use \`t.Context()\`.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`go test -timeout=60s ./exp/loom/...\` — green
- [ ] CI green on this PR