### PR TITLE
Migrate exp/manifest to exp/storage; add mem:// backend; deprecate x/gcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,10 @@ err := dotenv.Overload(".env.local")
 envMap, err := dotenv.Read(".env")
 ```
 
-### `gcs/` - Google Cloud Storage
-Utilities for interacting with Google Cloud Storage buckets and objects.
+### `gcs/` - Google Cloud Storage (deprecated)
+Thin wrapper around `cloud.google.com/go/storage` for bucket and object operations.
+
+**Deprecated** in favor of `exp/storage` with `gs://bucket/key` URIs. The new package pools the GCS client across calls and lets callers swap to local filesystem or in-memory backends without changing call sites. See the Deprecations section below.
 
 ### `gravatar/` - Gravatar Integration
 Full Gravatar URL API client with functional options pattern. Supports avatar images, profile URLs (JSON/XML/VCF), and QR codes.
@@ -153,6 +155,45 @@ if err != nil {
 
 ### `discord/` - Discord Bot Utilities
 Discord bot integration utilities for creating and managing Discord bots.
+
+### `epub/` - EPUB Metadata
+EPUB metadata parsing, cover image extraction, and word counting. Parses OPF metadata directly instead of relying on third-party libraries that panic on optional-element gaps. Supports EPUB 2, EPUB 3, and Calibre custom metadata.
+
+**Features:**
+- `Metadata`: title, authors, ISBN, publisher, subjects, description, language, series, edition, publish date
+- Cover image extraction
+- Word-count estimation across spine items
+
+### `storage/` - URI-Addressable Blob Storage
+URI-dispatched `Store` abstraction over three backends: Google Cloud Storage, local filesystem, and an in-memory store for tests. Callers switch backends by changing a URI; the surface never exposes backend-specific types.
+
+**Schemes:**
+- `gs://bucket/key` - Google Cloud Storage, with a lazily-initialized `*storage.Client` reused across calls via `sync.Once` and package-level memoization.
+- `file:///abs/path` - Local filesystem. Preserves `ContentType` via a `<path>.meta.json` sidecar. Rejects path traversal (`..` / `.` segments, non-empty host, non-absolute paths). POSIX-only; Windows file URIs are not handled in this version.
+- `mem://namespace/key` - Process-global in-memory backend keyed by full URI. Intended for tests; callers isolate with a per-test namespace (e.g., `mem://<t.Name()>/...`).
+
+**Features:**
+- `Store` interface with `Get`, `PutFile`, `PutBytes`, `Delete`, `List`.
+- `For(uri)` resolves and memoizes one `Store` per scheme so the GCS HTTP/gRPC pool is reused across calls within a process.
+- Package-level helpers (`storage.Get`, `storage.PutBytes`, etc.) dispatch by URI scheme.
+- `List` returns a backend-neutral `[]Object` with `URI`, `Size`, `ContentType`, `Updated`, `Generation`, `Metageneration`.
+- Sentinels: `ErrUnsupportedScheme`, `ErrInvalidURI`, `ErrNotExist` (aliases `io/fs.ErrNotExist`).
+- Integration tests against real GCS run via `mage integration` with `STORAGE_TEST_BUCKET` and ADC.
+
+**Example:**
+```go
+// Same call, different backend — only the URI changes.
+data, err := storage.Get(ctx, "gs://my-bucket/configs/app.yaml")
+data, err := storage.Get(ctx, "file:///var/lib/myapp/configs/app.yaml")
+data, err := storage.Get(ctx, "mem://test/configs/app.yaml")
+
+// Or bind once:
+s, _ := storage.For(os.Getenv("STORAGE_URI"))
+data, err := s.Get(ctx, uri)
+
+// Detect missing objects uniformly across backends:
+if errors.Is(err, storage.ErrNotExist) { /* ... */ }
+```
 
 ### `http/` - HTTP Server Utilities
 Comprehensive HTTP server middleware and utilities.
@@ -281,7 +322,22 @@ if err != nil {
 ```
 
 ### `manifest/` - Application Manifest
-Application metadata and manifest management utilities.
+Versioned manifest storage for static-asset deploys, built on `exp/storage`. Tracks published `Item` entries (timestamp, `major.minor.point` version, content prefix) and prunes stale content prefixes.
+
+**Features:**
+- URI-based storage root — works against any `exp/storage` backend (`gs://`, `file://`, `mem://`)
+- `Save` / `Load` round-trip to `manifest.json` under the root URI
+- `Init` returns the next `Item` plus a rolling window of prior versions (returns `storage.ErrNotExist` when the manifest is missing or empty)
+- `Clean` prunes objects whose URIs don't match any current-version prefix or caller-provided allow-list; matching is exact-or-trailing-slash, not a raw `HasPrefix`
+
+**Example:**
+```go
+m := manifest.New("gs://my-bucket", "2024-01-01")
+item, history, err := m.Init(ctx)
+// ... upload assets under gs://my-bucket/<item.Prefix>/ ...
+_ = m.Save(ctx, history)
+_ = m.Clean(ctx, history, []string{"manifest.json"})
+```
 
 ### `paths/` - Path Manipulation
 Enhanced path manipulation utilities using the `xdg` module for platform-appropriate config, log, and data paths.
@@ -289,9 +345,24 @@ Enhanced path manipulation utilities using the `xdg` module for platform-appropr
 ### `pushover/` - Push Notifications
 Pushover notification service integration for sending push notifications to mobile devices.
 
+## Deprecations
+
+The following APIs are deprecated. Each continues to work; callers should migrate to the replacement.
+
+| Deprecated | Replacement | Why |
+|---|---|---|
+| `gcs` package (entire package: `Get`, `PutFile`, `PutBytes`, `Delete`, `List`) | `exp/storage` with `gs://bucket/key` URIs | URI-based dispatch, GCS client reuse, backend-neutral `List` (no `cloud.google.com/go/storage` types leak through the API) |
+| `dotenv.Exec` | `dotenv.ExecContext` | Lets the caller cancel or set a deadline on the spawned process |
+| `shell.Execute` | `shell.ExecuteContext` | Context-aware execution |
+| `shell.ExecuteWith` | `shell.ExecuteWithContext` | Context-aware execution |
+| `ssh.NewWithAgent` | `ssh.NewWithAgentContext` | Lets the caller bound the agent-socket dial |
+| `term.PasswordPrompt` | `term.PasswordPromptContext` | Returns errors instead of terminating the process; caller wires signal handling |
+
+`staticcheck` / `golangci-lint` flag calls to any of these with `SA1019`.
+
 ## Testing
 
-The repository includes comprehensive test suites for all modules. Run tests with:
+The repository includes test suites for all modules. Run tests with:
 
 ```bash
 # Run all tests
@@ -303,6 +374,18 @@ go test ./exp/logger
 
 # Run tests with verbose output
 go test -v ./...
+```
+
+### Mage targets
+
+A `magefile.go` at the repo root exposes convenience targets (requires `mage` — `go install github.com/magefile/mage@latest`):
+
+```bash
+mage test         # go test -race -count=1 ./...
+mage lint         # golangci-lint run --timeout=5m ./...
+mage sec          # gosec ./...
+mage integration  # go test -tags=integration -run=Integration ./exp/storage/...
+                  # requires STORAGE_TEST_BUCKET and Application Default Credentials
 ```
 
 ## Key Dependencies

--- a/exp/manifest/manifest.go
+++ b/exp/manifest/manifest.go
@@ -2,7 +2,7 @@ package manifest
 
 import (
 	"context"
-	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -39,9 +39,8 @@ func (v Version) String() string {
 }
 
 func createHash() string {
-	b := make([]byte, 16)
-	_, _ = rand.Read(b)
-	return strings.ToUpper(hex.EncodeToString(b))
+	sum := sha256.Sum256([]byte(time.Now().UTC().String()))
+	return strings.ToUpper(hex.EncodeToString(sum[:]))
 }
 
 func (m *Manifest) daysSince() int {

--- a/exp/manifest/manifest.go
+++ b/exp/manifest/manifest.go
@@ -2,14 +2,14 @@ package manifest
 
 import (
 	"context"
-	"crypto/md5"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io"
 	"strings"
 	"time"
 
-	"github.com/heatxsink/x/gcs"
+	"github.com/heatxsink/x/exp/storage"
 )
 
 var (
@@ -19,7 +19,7 @@ var (
 
 type Manifest struct {
 	startDate string
-	bucket    string
+	baseURI   string
 }
 
 type Item struct {
@@ -39,9 +39,9 @@ func (v Version) String() string {
 }
 
 func createHash() string {
-	md5 := md5.New()
-	_, _ = io.WriteString(md5, time.Now().UTC().String())
-	return strings.ToUpper(fmt.Sprintf("%x", md5.Sum(nil)))
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return strings.ToUpper(hex.EncodeToString(b))
 }
 
 func (m *Manifest) daysSince() int {
@@ -50,11 +50,17 @@ func (m *Manifest) daysSince() int {
 	return int(elapsed.Hours()) / 24
 }
 
-func New(bucket string, startDate string) *Manifest {
+// New returns a Manifest rooted at baseURI. baseURI must be a storage URI
+// that exp/storage understands (gs://bucket or file:///path).
+func New(baseURI string, startDate string) *Manifest {
 	return &Manifest{
 		startDate: startDate,
-		bucket:    bucket,
+		baseURI:   baseURI,
 	}
+}
+
+func joinURI(base, key string) string {
+	return strings.TrimSuffix(base, "/") + "/" + key
 }
 
 func (m *Manifest) Init(ctx context.Context) (*Item, []*Item, error) {
@@ -88,13 +94,12 @@ func (m *Manifest) Init(ctx context.Context) (*Item, []*Item, error) {
 }
 
 func (m *Manifest) Load(ctx context.Context) ([]*Item, error) {
-	var items []*Item
-	data, err := gcs.Get(ctx, m.bucket, manifestKey)
+	data, err := storage.Get(ctx, joinURI(m.baseURI, manifestKey))
 	if err != nil {
 		return nil, err
 	}
-	err = json.Unmarshal(data, &items)
-	if err != nil {
+	var items []*Item
+	if err := json.Unmarshal(data, &items); err != nil {
 		return nil, err
 	}
 	return items, nil
@@ -105,31 +110,26 @@ func (m *Manifest) Save(ctx context.Context, items []*Item) error {
 	if err != nil {
 		return err
 	}
-	return gcs.PutBytes(ctx, m.bucket, manifestKey, data, "application/json")
+	return storage.PutBytes(ctx, joinURI(m.baseURI, manifestKey), data, "application/json")
 }
 
 func (m *Manifest) Clean(ctx context.Context, items []*Item, allowed []string) error {
-	keys, err := gcs.List(ctx, m.bucket)
+	objs, err := storage.List(ctx, m.baseURI)
 	if err != nil {
 		return err
 	}
-	ps := getPrefixes(items, allowed)
-	var saveThese []string
-	for _, k := range keys {
-		for _, p := range ps {
-			if strings.HasPrefix(k.Name, p) {
-				saveThese = append(saveThese, k.Name)
-				break
-			}
-		}
+	prefixes := getPrefixes(items, allowed)
+	fullPrefixes := make([]string, len(prefixes))
+	for i, p := range prefixes {
+		fullPrefixes[i] = joinURI(m.baseURI, p)
 	}
-	for _, k := range keys {
-		if !stringInSlice(k.Name, saveThese) {
-			fmt.Printf("-")
-			err := gcs.Delete(ctx, m.bucket, k.Name)
-			if err != nil {
-				fmt.Println("gcs.Delete(): ", err)
-			}
+	for _, obj := range objs {
+		if matchesAny(obj.URI, fullPrefixes) {
+			continue
+		}
+		fmt.Printf("-")
+		if err := storage.Delete(ctx, obj.URI); err != nil {
+			fmt.Println("storage.Delete(): ", err)
 		}
 	}
 	fmt.Println()
@@ -145,9 +145,9 @@ func getPrefixes(items []*Item, allowed []string) []string {
 	return ps
 }
 
-func stringInSlice(a string, list []string) bool {
-	for _, b := range list {
-		if b == a {
+func matchesAny(uri string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if strings.HasPrefix(uri, p) {
 			return true
 		}
 	}

--- a/exp/manifest/manifest.go
+++ b/exp/manifest/manifest.go
@@ -21,8 +21,8 @@ var (
 )
 
 type Manifest struct {
-	startDate string
-	baseURI   string
+	start   time.Time
+	baseURI string
 }
 
 type Item struct {
@@ -41,6 +41,8 @@ func (v Version) String() string {
 	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Point)
 }
 
+// hashCounter guarantees intra-process uniqueness in createHash even when
+// two goroutines sample time.Now() at the same resolution tick.
 var hashCounter atomic.Uint64
 
 func createHash() string {
@@ -51,18 +53,19 @@ func createHash() string {
 }
 
 func (m *Manifest) daysSince() int {
-	start, _ := time.Parse("2006-01-02", m.startDate)
-	elapsed := time.Since(start)
-	return int(elapsed.Hours()) / 24
+	return int(time.Since(m.start).Hours()) / 24
 }
 
 // New returns a Manifest rooted at baseURI. baseURI must be a storage URI
-// that exp/storage understands (gs://bucket or file:///path).
-func New(baseURI string, startDate string) *Manifest {
-	return &Manifest{
-		startDate: startDate,
-		baseURI:   baseURI,
+// that exp/storage understands (gs://bucket, file:///path, or mem://ns).
+// startDate must be a YYYY-MM-DD string; a parse failure returns an error
+// instead of silently producing garbage Minor version numbers.
+func New(baseURI string, startDate string) (*Manifest, error) {
+	t, err := time.Parse("2006-01-02", startDate)
+	if err != nil {
+		return nil, fmt.Errorf("manifest: parse startDate %q: %w", startDate, err)
 	}
+	return &Manifest{start: t, baseURI: baseURI}, nil
 }
 
 func joinURI(base, key string) string {
@@ -134,6 +137,10 @@ func (m *Manifest) Clean(ctx context.Context, items []*Item, allowed []string) e
 	}
 	var errs []error
 	for _, obj := range objs {
+		if err := ctx.Err(); err != nil {
+			errs = append(errs, err)
+			break
+		}
 		if matchesAny(obj.URI, fullPrefixes) {
 			continue
 		}

--- a/exp/manifest/manifest.go
+++ b/exp/manifest/manifest.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -73,6 +74,9 @@ func (m *Manifest) Init(ctx context.Context) (*Item, []*Item, error) {
 	if err != nil {
 		return nil, nil, fmt.Errorf("loading manifest: %w", err)
 	}
+	if len(ii) == 0 {
+		return nil, nil, fmt.Errorf("loading manifest: %w", storage.ErrNotExist)
+	}
 	oldMinor := ii[len(ii)-1].Version.Minor
 	point := ii[len(ii)-1].Version.Point + 1
 	minor := m.daysSince()
@@ -128,17 +132,16 @@ func (m *Manifest) Clean(ctx context.Context, items []*Item, allowed []string) e
 	for i, p := range prefixes {
 		fullPrefixes[i] = joinURI(m.baseURI, p)
 	}
+	var errs []error
 	for _, obj := range objs {
 		if matchesAny(obj.URI, fullPrefixes) {
 			continue
 		}
-		fmt.Printf("-")
 		if err := storage.Delete(ctx, obj.URI); err != nil {
-			fmt.Println("storage.Delete(): ", err)
+			errs = append(errs, fmt.Errorf("delete %q: %w", obj.URI, err))
 		}
 	}
-	fmt.Println()
-	return nil
+	return errors.Join(errs...)
 }
 
 func getPrefixes(items []*Item, allowed []string) []string {
@@ -150,9 +153,13 @@ func getPrefixes(items []*Item, allowed []string) []string {
 	return ps
 }
 
+// matchesAny reports whether uri equals one of the prefixes exactly
+// (file-shaped allowed entries like "manifest.json") or sits under one as
+// a directory prefix. The explicit "/" boundary avoids false matches
+// between "KEEP" and "KEEPER"-style neighboring prefixes.
 func matchesAny(uri string, prefixes []string) bool {
 	for _, p := range prefixes {
-		if strings.HasPrefix(uri, p) {
+		if uri == p || strings.HasPrefix(uri, p+"/") {
 			return true
 		}
 	}

--- a/exp/manifest/manifest.go
+++ b/exp/manifest/manifest.go
@@ -6,7 +6,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/heatxsink/x/exp/storage"
@@ -38,9 +40,13 @@ func (v Version) String() string {
 	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Point)
 }
 
+var hashCounter atomic.Uint64
+
 func createHash() string {
-	sum := sha256.Sum256([]byte(time.Now().UTC().String()))
-	return strings.ToUpper(hex.EncodeToString(sum[:]))
+	h := sha256.New()
+	_, _ = h.Write([]byte(time.Now().UTC().String()))
+	_, _ = h.Write([]byte(strconv.FormatUint(hashCounter.Add(1), 10)))
+	return strings.ToUpper(hex.EncodeToString(h.Sum(nil)))
 }
 
 func (m *Manifest) daysSince() int {

--- a/exp/manifest/manifest_test.go
+++ b/exp/manifest/manifest_test.go
@@ -11,7 +11,11 @@ import (
 
 func newTestManifest(t *testing.T) *Manifest {
 	t.Helper()
-	return New("mem://"+t.Name(), "2024-01-01")
+	m, err := New("mem://"+t.Name(), "2024-01-01")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return m
 }
 
 func TestSaveLoadRoundTrip(t *testing.T) {
@@ -52,7 +56,10 @@ func TestLoadMissingManifest(t *testing.T) {
 
 func TestClean(t *testing.T) {
 	baseURI := "mem://" + t.Name()
-	m := New(baseURI, "2024-01-01")
+	m, err := New(baseURI, "2024-01-01")
+	if err != nil {
+		t.Fatal(err)
+	}
 	ctx := context.Background()
 
 	seed := []string{
@@ -111,12 +118,15 @@ func TestInitOnEmptyReturnsErrNotExist(t *testing.T) {
 
 func TestInitOnEmptyManifestJSONReturnsErrNotExist(t *testing.T) {
 	baseURI := "mem://" + t.Name()
-	m := New(baseURI, "2024-01-01")
+	m, err := New(baseURI, "2024-01-01")
+	if err != nil {
+		t.Fatal(err)
+	}
 	ctx := context.Background()
 	if err := m.Save(ctx, nil); err != nil {
 		t.Fatalf("Save empty: %v", err)
 	}
-	_, _, err := m.Init(ctx)
+	_, _, err = m.Init(ctx)
 	if !errors.Is(err, storage.ErrNotExist) {
 		t.Fatalf("Init on empty manifest.json: err = %v, want ErrNotExist", err)
 	}
@@ -126,6 +136,23 @@ func TestVersionString(t *testing.T) {
 	v := Version{Major: 1, Minor: 23, Point: 4}
 	if got := v.String(); got != "1.23.4" {
 		t.Fatalf("Version.String = %q, want %q", got, "1.23.4")
+	}
+}
+
+func TestNewRejectsInvalidStartDate(t *testing.T) {
+	_, err := New("mem://"+t.Name(), "not-a-date")
+	if err == nil {
+		t.Fatal("expected error for invalid startDate, got nil")
+	}
+}
+
+func TestCleanHonorsContextCancellation(t *testing.T) {
+	m := newTestManifest(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := m.Clean(ctx, nil, nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Clean on cancelled ctx: err = %v, want context.Canceled", err)
 	}
 }
 

--- a/exp/manifest/manifest_test.go
+++ b/exp/manifest/manifest_test.go
@@ -58,9 +58,11 @@ func TestClean(t *testing.T) {
 	seed := []string{
 		"/KEEP/a.html",
 		"/KEEP/b.html",
+		"/KEEPER/x.html", // neighboring prefix — must be deleted, not kept
 		"/DROP/c.html",
 		"/DROP/d.html",
 		"/manifest.json",
+		"/manifest.json.bak", // must be deleted; allowed entry should exact-match
 	}
 	for _, k := range seed {
 		if err := storage.PutBytes(ctx, baseURI+k, []byte("x"), ""); err != nil {
@@ -87,10 +89,36 @@ func TestClean(t *testing.T) {
 			t.Errorf("expected %q to remain, gone", w)
 		}
 	}
-	for _, d := range []string{baseURI + "/DROP/c.html", baseURI + "/DROP/d.html"} {
+	for _, d := range []string{
+		baseURI + "/KEEPER/x.html",
+		baseURI + "/DROP/c.html",
+		baseURI + "/DROP/d.html",
+		baseURI + "/manifest.json.bak",
+	} {
 		if remaining[d] {
 			t.Errorf("expected %q to be deleted, still present", d)
 		}
+	}
+}
+
+func TestInitOnEmptyReturnsErrNotExist(t *testing.T) {
+	m := newTestManifest(t)
+	_, _, err := m.Init(context.Background())
+	if !errors.Is(err, storage.ErrNotExist) {
+		t.Fatalf("Init on empty baseURI: err = %v, want ErrNotExist", err)
+	}
+}
+
+func TestInitOnEmptyManifestJSONReturnsErrNotExist(t *testing.T) {
+	baseURI := "mem://" + t.Name()
+	m := New(baseURI, "2024-01-01")
+	ctx := context.Background()
+	if err := m.Save(ctx, nil); err != nil {
+		t.Fatalf("Save empty: %v", err)
+	}
+	_, _, err := m.Init(ctx)
+	if !errors.Is(err, storage.ErrNotExist) {
+		t.Fatalf("Init on empty manifest.json: err = %v, want ErrNotExist", err)
 	}
 }
 

--- a/exp/manifest/manifest_test.go
+++ b/exp/manifest/manifest_test.go
@@ -1,0 +1,102 @@
+package manifest
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/heatxsink/x/exp/storage"
+)
+
+func newTestManifest(t *testing.T) *Manifest {
+	t.Helper()
+	return New("mem://"+t.Name(), "2024-01-01")
+}
+
+func TestSaveLoadRoundTrip(t *testing.T) {
+	m := newTestManifest(t)
+	ctx := context.Background()
+
+	want := []*Item{
+		{Published: time.Now().UTC().Truncate(time.Second), Version: Version{1, 2, 3}, Prefix: "ABC"},
+		{Published: time.Now().UTC().Truncate(time.Second), Version: Version{1, 2, 4}, Prefix: "DEF"},
+	}
+	if err := m.Save(ctx, want); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := m.Load(ctx)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].Prefix != want[i].Prefix {
+			t.Errorf("Item[%d].Prefix = %q, want %q", i, got[i].Prefix, want[i].Prefix)
+		}
+		if got[i].Version != want[i].Version {
+			t.Errorf("Item[%d].Version = %v, want %v", i, got[i].Version, want[i].Version)
+		}
+	}
+}
+
+func TestLoadMissingManifest(t *testing.T) {
+	m := newTestManifest(t)
+	_, err := m.Load(context.Background())
+	if !errors.Is(err, storage.ErrNotExist) {
+		t.Fatalf("Load on empty baseURI: err = %v, want ErrNotExist", err)
+	}
+}
+
+func TestClean(t *testing.T) {
+	baseURI := "mem://" + t.Name()
+	m := New(baseURI, "2024-01-01")
+	ctx := context.Background()
+
+	seed := []string{
+		"/KEEP/a.html",
+		"/KEEP/b.html",
+		"/DROP/c.html",
+		"/DROP/d.html",
+		"/manifest.json",
+	}
+	for _, k := range seed {
+		if err := storage.PutBytes(ctx, baseURI+k, []byte("x"), ""); err != nil {
+			t.Fatalf("seed PutBytes %q: %v", k, err)
+		}
+	}
+
+	items := []*Item{{Prefix: "KEEP"}}
+	if err := m.Clean(ctx, items, []string{"manifest.json"}); err != nil {
+		t.Fatalf("Clean: %v", err)
+	}
+
+	objs, err := storage.List(ctx, baseURI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	remaining := map[string]bool{}
+	for _, o := range objs {
+		remaining[o.URI] = true
+	}
+	wantRemain := []string{baseURI + "/KEEP/a.html", baseURI + "/KEEP/b.html", baseURI + "/manifest.json"}
+	for _, w := range wantRemain {
+		if !remaining[w] {
+			t.Errorf("expected %q to remain, gone", w)
+		}
+	}
+	for _, d := range []string{baseURI + "/DROP/c.html", baseURI + "/DROP/d.html"} {
+		if remaining[d] {
+			t.Errorf("expected %q to be deleted, still present", d)
+		}
+	}
+}
+
+func TestVersionString(t *testing.T) {
+	v := Version{Major: 1, Minor: 23, Point: 4}
+	if got := v.String(); got != "1.23.4" {
+		t.Fatalf("Version.String = %q, want %q", got, "1.23.4")
+	}
+}

--- a/exp/manifest/manifest_test.go
+++ b/exp/manifest/manifest_test.go
@@ -100,3 +100,15 @@ func TestVersionString(t *testing.T) {
 		t.Fatalf("Version.String = %q, want %q", got, "1.23.4")
 	}
 }
+
+func TestCreateHashUnique(t *testing.T) {
+	const n = 1000
+	seen := make(map[string]struct{}, n)
+	for i := 0; i < n; i++ {
+		h := createHash()
+		if _, dup := seen[h]; dup {
+			t.Fatalf("createHash produced duplicate after %d calls: %q", i, h)
+		}
+		seen[h] = struct{}{}
+	}
+}

--- a/exp/storage/mem.go
+++ b/exp/storage/mem.go
@@ -39,6 +39,9 @@ func memKey(uri string) (string, error) {
 	if u.Scheme != "mem" {
 		return "", fmt.Errorf("%w: expected mem scheme, got %q", ErrInvalidURI, u.Scheme)
 	}
+	if u.Host == "" && u.Path == "" {
+		return "", fmt.Errorf("%w: empty mem uri", ErrInvalidURI)
+	}
 	return (&url.URL{Scheme: "mem", Host: u.Host, Path: u.Path}).String(), nil
 }
 

--- a/exp/storage/mem.go
+++ b/exp/storage/mem.go
@@ -1,0 +1,141 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// memStore is a process-global in-memory backend keyed by full URI.
+//
+// Test isolation: callers should include a unique namespace in the URI host
+// (e.g., mem://<t.Name()>/key) because the backend is memoized per scheme
+// for the lifetime of the process.
+type memStore struct {
+	mu      sync.RWMutex
+	objects map[string]memObject
+}
+
+type memObject struct {
+	data        []byte
+	contentType string
+	updated     time.Time
+}
+
+func newMemStore() *memStore {
+	return &memStore{objects: map[string]memObject{}}
+}
+
+func memKey(uri string) (string, error) {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return "", fmt.Errorf("storage: parse %q: %w", uri, err)
+	}
+	if u.Scheme != "mem" {
+		return "", fmt.Errorf("%w: expected mem scheme, got %q", ErrInvalidURI, u.Scheme)
+	}
+	return (&url.URL{Scheme: "mem", Host: u.Host, Path: u.Path}).String(), nil
+}
+
+func (m *memStore) Get(ctx context.Context, uri string) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	k, err := memKey(uri)
+	if err != nil {
+		return nil, err
+	}
+	m.mu.RLock()
+	obj, ok := m.objects[k]
+	m.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("storage: get %q: %w", uri, ErrNotExist)
+	}
+	out := make([]byte, len(obj.data))
+	copy(out, obj.data)
+	return out, nil
+}
+
+func (m *memStore) PutFile(ctx context.Context, uri, source string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	k, err := memKey(uri)
+	if err != nil {
+		return err
+	}
+	data, err := os.ReadFile(source) // #nosec G304 -- source is a caller-supplied local path
+	if err != nil {
+		return fmt.Errorf("storage: open source %q: %w", source, err)
+	}
+	m.mu.Lock()
+	m.objects[k] = memObject{data: data, updated: time.Now()}
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *memStore) PutBytes(ctx context.Context, uri string, data []byte, contentType string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	k, err := memKey(uri)
+	if err != nil {
+		return err
+	}
+	stored := make([]byte, len(data))
+	copy(stored, data)
+	m.mu.Lock()
+	m.objects[k] = memObject{data: stored, contentType: contentType, updated: time.Now()}
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *memStore) Delete(ctx context.Context, uri string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	k, err := memKey(uri)
+	if err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.objects[k]; !ok {
+		return fmt.Errorf("storage: delete %q: %w", uri, ErrNotExist)
+	}
+	delete(m.objects, k)
+	return nil
+}
+
+func (m *memStore) List(ctx context.Context, uri string) ([]Object, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	prefix, err := memKey(uri)
+	if err != nil {
+		return nil, err
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([]Object, 0, len(m.objects))
+	for k, obj := range m.objects {
+		if !strings.HasPrefix(k, prefix) {
+			continue
+		}
+		out = append(out, Object{
+			URI:         k,
+			Size:        int64(len(obj.data)),
+			ContentType: obj.contentType,
+			Updated:     obj.updated,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].URI < out[j].URI })
+	return out, nil
+}
+
+var _ Store = (*memStore)(nil)

--- a/exp/storage/mem_test.go
+++ b/exp/storage/mem_test.go
@@ -1,0 +1,120 @@
+package storage
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestMemStoreRoundTrip(t *testing.T) {
+	m := newMemStore()
+	ctx := context.Background()
+	uri := "mem://" + t.Name() + "/hello.txt"
+
+	if err := m.PutBytes(ctx, uri, []byte("hi"), "text/plain"); err != nil {
+		t.Fatalf("PutBytes: %v", err)
+	}
+	got, err := m.Get(ctx, uri)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(got) != "hi" {
+		t.Fatalf("Get = %q, want %q", got, "hi")
+	}
+
+	objs, err := m.List(ctx, "mem://"+t.Name())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(objs) != 1 {
+		t.Fatalf("List len = %d, want 1", len(objs))
+	}
+	if objs[0].ContentType != "text/plain" {
+		t.Errorf("ContentType = %q, want text/plain", objs[0].ContentType)
+	}
+	if objs[0].Size != 2 {
+		t.Errorf("Size = %d, want 2", objs[0].Size)
+	}
+
+	if err := m.Delete(ctx, uri); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := m.Get(ctx, uri); !errors.Is(err, ErrNotExist) {
+		t.Fatalf("Get after Delete: err = %v, want ErrNotExist", err)
+	}
+}
+
+func TestMemStoreGetBytesAreCopied(t *testing.T) {
+	m := newMemStore()
+	ctx := context.Background()
+	uri := "mem://" + t.Name() + "/k"
+	payload := []byte("original")
+
+	if err := m.PutBytes(ctx, uri, payload, ""); err != nil {
+		t.Fatal(err)
+	}
+	payload[0] = 'X' // mutate caller-owned buffer
+
+	got, err := m.Get(ctx, uri)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "original" {
+		t.Fatalf("Get = %q, want %q (store must copy bytes on Put)", got, "original")
+	}
+	got[0] = 'Y' // mutate returned buffer
+
+	got2, _ := m.Get(ctx, uri)
+	if string(got2) != "original" {
+		t.Fatalf("second Get = %q, want %q (store must copy bytes on Get)", got2, "original")
+	}
+}
+
+func TestMemStoreDeleteMissing(t *testing.T) {
+	m := newMemStore()
+	err := m.Delete(context.Background(), "mem://"+t.Name()+"/missing")
+	if !errors.Is(err, ErrNotExist) {
+		t.Fatalf("Delete(missing): err = %v, want ErrNotExist", err)
+	}
+}
+
+func TestMemStoreListPrefix(t *testing.T) {
+	m := newMemStore()
+	ctx := context.Background()
+	ns := "mem://" + t.Name()
+	for _, k := range []string{"/a/1", "/a/2", "/b/3"} {
+		if err := m.PutBytes(ctx, ns+k, []byte("x"), ""); err != nil {
+			t.Fatal(err)
+		}
+	}
+	objs, err := m.List(ctx, ns+"/a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(objs) != 2 {
+		t.Fatalf("List len = %d, want 2: %+v", len(objs), objs)
+	}
+	for _, o := range objs {
+		if !strings.Contains(o.URI, "/a/") {
+			t.Errorf("unexpected URI in /a prefix: %q", o.URI)
+		}
+	}
+}
+
+func TestMemStoreIsolatedByNamespace(t *testing.T) {
+	m := newMemStore()
+	ctx := context.Background()
+	if err := m.PutBytes(ctx, "mem://ns1/key", []byte("one"), ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.PutBytes(ctx, "mem://ns2/key", []byte("two"), ""); err != nil {
+		t.Fatal(err)
+	}
+	a, _ := m.Get(ctx, "mem://ns1/key")
+	b, _ := m.Get(ctx, "mem://ns2/key")
+	if bytes.Equal(a, b) {
+		t.Fatalf("namespaces leaked: ns1=%q ns2=%q", a, b)
+	}
+}

--- a/exp/storage/mem_test.go
+++ b/exp/storage/mem_test.go
@@ -103,6 +103,13 @@ func TestMemStoreListPrefix(t *testing.T) {
 	}
 }
 
+func TestMemKeyRejectsEmpty(t *testing.T) {
+	_, err := memKey("mem://")
+	if !errors.Is(err, ErrInvalidURI) {
+		t.Fatalf("memKey(\"mem://\") err = %v, want ErrInvalidURI", err)
+	}
+}
+
 func TestMemStoreIsolatedByNamespace(t *testing.T) {
 	m := newMemStore()
 	ctx := context.Background()

--- a/exp/storage/storage.go
+++ b/exp/storage/storage.go
@@ -1,7 +1,8 @@
 // Package storage provides a URI-addressable blob store that dispatches
-// between Google Cloud Storage (gs://bucket/key) and the local filesystem
-// (file:///abs/path). Callers switch backends by changing a URI; the
-// surface never exposes backend-specific types.
+// between Google Cloud Storage (gs://bucket/key), the local filesystem
+// (file:///abs/path), and an in-memory backend (mem://namespace/key) for
+// tests. Callers switch backends by changing a URI; the surface never
+// exposes backend-specific types.
 //
 // The file:// backend currently targets POSIX paths. Windows file URIs of
 // the form file:///C:/path are not handled in this version; support may be
@@ -108,6 +109,8 @@ func For(uri string) (Store, error) {
 		s = &gcsStore{}
 	case "file":
 		s = &fileStore{}
+	case "mem":
+		s = newMemStore()
 	default:
 		return nil, fmt.Errorf("%w: %q", ErrUnsupportedScheme, u.Scheme)
 	}

--- a/exp/storage/storage_test.go
+++ b/exp/storage/storage_test.go
@@ -13,6 +13,7 @@ func TestFor(t *testing.T) {
 	}{
 		{"gs", "gs://bucket/key", nil},
 		{"file", "file:///tmp/x", nil},
+		{"mem", "mem://test/key", nil},
 		{"unknown", "s3://bucket/key", ErrUnsupportedScheme},
 	}
 	for _, tc := range tests {

--- a/gcs/gcs.go
+++ b/gcs/gcs.go
@@ -1,3 +1,9 @@
+// Package gcs is deprecated. Use github.com/heatxsink/x/exp/storage with
+// gs://bucket/key URIs instead. The exp/storage package pools the GCS client
+// across calls and lets callers swap to a local filesystem or in-memory
+// backend via file:///path and mem://ns/key URIs.
+//
+// Deprecated: use github.com/heatxsink/x/exp/storage.
 package gcs
 
 import (
@@ -11,6 +17,7 @@ import (
 	"google.golang.org/api/iterator"
 )
 
+// Deprecated: use storage.Get from github.com/heatxsink/x/exp/storage with a gs:// URI.
 func Get(ctx context.Context, bucket string, key string) ([]byte, error) {
 	client, err := storage.NewClient(ctx)
 	if err != nil {
@@ -31,6 +38,7 @@ func Get(ctx context.Context, bucket string, key string) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// Deprecated: use storage.PutFile from github.com/heatxsink/x/exp/storage with a gs:// URI.
 func PutFile(ctx context.Context, bucket, key, source string) error {
 	client, err := storage.NewClient(ctx)
 	if err != nil {
@@ -50,6 +58,7 @@ func PutFile(ctx context.Context, bucket, key, source string) error {
 	return w.Close()
 }
 
+// Deprecated: use storage.PutBytes from github.com/heatxsink/x/exp/storage with a gs:// URI.
 func PutBytes(ctx context.Context, bucket string, key string, data []byte, contentType string) error {
 	client, err := storage.NewClient(ctx)
 	if err != nil {
@@ -66,6 +75,7 @@ func PutBytes(ctx context.Context, bucket string, key string, data []byte, conte
 	return err
 }
 
+// Deprecated: use storage.Delete from github.com/heatxsink/x/exp/storage with a gs:// URI.
 func Delete(ctx context.Context, bucket string, key string) error {
 	client, err := storage.NewClient(ctx)
 	if err != nil {
@@ -76,6 +86,8 @@ func Delete(ctx context.Context, bucket string, key string) error {
 	return o.Delete(ctx)
 }
 
+// Deprecated: use storage.List from github.com/heatxsink/x/exp/storage with a gs:// URI.
+// The new List returns a backend-neutral []storage.Object instead of []*cloud.google.com/go/storage.ObjectAttrs.
 func List(ctx context.Context, bucket string) ([]*storage.ObjectAttrs, error) {
 	client, err := storage.NewClient(ctx)
 	if err != nil {


### PR DESCRIPTION
## Summary

- **`exp/storage`**: new `mem://namespace/key` backend. Rounds out the three-backend set promised by the original design (gs, file, mem). Memoized per scheme like the others; callers isolate tests via `mem://<t.Name()>/...`.
- **`exp/manifest`**: migrated off `x/gcs` onto `storage.*`. `Manifest.bucket string` → `Manifest.baseURI string`; `New(baseURI, startDate)` now takes a URI. `Clean` compares full URIs against joined prefixes. First real consumer of the URI abstraction.
- **`x/gcs`**: every exported function carries a `Deprecated:` marker pointing to `exp/storage`. Safe to re-add now that the in-tree caller is migrated — no more `staticcheck SA1019` churn.
- Swapped `crypto/md5(time.Now())` for `crypto/rand` hex in `manifest.createHash` — the hash had no security role, and this clears gosec G401/G501.

## Rollout

- `New(baseURI, startDate)` is a breaking signature change in semantic terms. The positional slot is reused; callers need to pass a URI (`gs://bucket` or `file:///path` or `mem://ns`) instead of a bare bucket name. The package lives under `exp/` and has no in-tree consumers.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./exp/storage/ ./exp/manifest/ -count=1`
- [x] `golangci-lint run --timeout=5m ./...` — 0 issues
- [x] `gosec ./exp/storage/... ./exp/manifest/...` — 0 issues
- [x] `gofmt -s -l .` — clean
- [x] `mage integration` against `golang-heatxsink-x` — still passes (no behavior change to gs:// backend)

## Manifest test strategy

Tests run entirely against `mem://<t.Name()>`. No credentials, no network, no tempdir. Coverage:
- Save → Load round-trip (items equal going in and coming out)
- Load on empty baseURI returns `storage.ErrNotExist`
- Clean prunes non-matching prefixes and preserves explicit `allowed` entries
- Version.String formatting