### PR TITLE
Tighten exp/paths directory permissions to 0o700

### DIFF
--- a/exp/paths/paths.go
+++ b/exp/paths/paths.go
@@ -26,7 +26,7 @@ func New(name string) (*Paths, error) {
 		return nil, err
 	}
 	p.LogPath = filepath.Dir(p.LogFilename)
-	err = os.MkdirAll(p.LogPath, 0o750)
+	err = os.MkdirAll(p.LogPath, 0o700)
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +36,7 @@ func New(name string) (*Paths, error) {
 		return nil, err
 	}
 	p.ConfigPath = filepath.Dir(p.ConfigFilename)
-	err = os.MkdirAll(p.ConfigPath, 0o750)
+	err = os.MkdirAll(p.ConfigPath, 0o700)
 	if err != nil {
 		return nil, err
 	}

--- a/exp/paths/paths.go
+++ b/exp/paths/paths.go
@@ -26,7 +26,7 @@ func New(name string) (*Paths, error) {
 		return nil, err
 	}
 	p.LogPath = filepath.Dir(p.LogFilename)
-	err = os.MkdirAll(p.LogPath, os.ModePerm)
+	err = os.MkdirAll(p.LogPath, 0o750)
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +36,7 @@ func New(name string) (*Paths, error) {
 		return nil, err
 	}
 	p.ConfigPath = filepath.Dir(p.ConfigFilename)
-	err = os.MkdirAll(p.ConfigPath, os.ModePerm)
+	err = os.MkdirAll(p.ConfigPath, 0o750)
 	if err != nil {
 		return nil, err
 	}

--- a/exp/paths/paths_test.go
+++ b/exp/paths/paths_test.go
@@ -1,0 +1,54 @@
+package paths
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestNewCreatesDirectoriesWithStrictMode(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	// Force xdg to fall through to HOME-relative defaults.
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_STATE_HOME", "")
+	t.Setenv("XDG_CACHE_HOME", "")
+
+	p, err := New("paths-test")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	for label, dir := range map[string]string{"LogPath": p.LogPath, "ConfigPath": p.ConfigPath} {
+		if !strings.HasPrefix(dir, tmp) {
+			t.Fatalf("%s = %q, want a path under tmp %q", label, dir, tmp)
+		}
+		info, err := os.Stat(dir)
+		if err != nil {
+			t.Fatalf("stat %s %q: %v", label, dir, err)
+		}
+		if mode := info.Mode().Perm(); mode != 0o700 {
+			t.Errorf("%s %q mode = %o, want 0o700", label, dir, mode)
+		}
+	}
+}
+
+func TestNewPopulatesFilenames(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_STATE_HOME", "")
+	t.Setenv("XDG_CACHE_HOME", "")
+
+	p, err := New("paths-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(p.LogFilename, "paths-test.log") {
+		t.Errorf("LogFilename = %q, want suffix paths-test.log", p.LogFilename)
+	}
+	if !strings.HasSuffix(p.ConfigFilename, "paths-test.yaml") {
+		t.Errorf("ConfigFilename = %q, want suffix paths-test.yaml", p.ConfigFilename)
+	}
+}

--- a/exp/paths/paths_test.go
+++ b/exp/paths/paths_test.go
@@ -2,18 +2,29 @@ package paths
 
 import (
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 )
 
-func TestNewCreatesDirectoriesWithStrictMode(t *testing.T) {
+// setupHermeticHome points HOME and every XDG_*_HOME at a per-test tempdir
+// so paths.New writes stay isolated from the real user environment.
+func setupHermeticHome(t *testing.T) string {
+	t.Helper()
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
-	// Force xdg to fall through to HOME-relative defaults.
 	t.Setenv("XDG_CONFIG_HOME", "")
 	t.Setenv("XDG_DATA_HOME", "")
 	t.Setenv("XDG_STATE_HOME", "")
 	t.Setenv("XDG_CACHE_HOME", "")
+	return tmp
+}
+
+func TestNewCreatesDirectoriesWithStrictMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits are not meaningful on Windows")
+	}
+	tmp := setupHermeticHome(t)
 
 	p, err := New("paths-test")
 	if err != nil {
@@ -35,11 +46,7 @@ func TestNewCreatesDirectoriesWithStrictMode(t *testing.T) {
 }
 
 func TestNewPopulatesFilenames(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", "")
-	t.Setenv("XDG_DATA_HOME", "")
-	t.Setenv("XDG_STATE_HOME", "")
-	t.Setenv("XDG_CACHE_HOME", "")
+	setupHermeticHome(t)
 
 	p, err := New("paths-test")
 	if err != nil {


### PR DESCRIPTION
## Summary

- `exp/paths/paths.go:29,39` previously passed `os.ModePerm` (0o777) to `os.MkdirAll` for the log and config directories, making them world-writable.
- Tighten both to `0o700`. `paths.New` uses `xdg.User` scope — the directories are single-user by design and group access is never required. `0o700` matches the actual access pattern better than `0o750` would.
- Clears gosec G301 (alerts #18, #19 in the code-scanning history).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./exp/paths/... -count=1 -v` — new `paths_test.go` covers directory mode and filename contracts, hermetic via `HOME` + `XDG_*_HOME` overrides
- [x] `golangci-lint run --timeout=5m ./exp/paths/...` — 0 issues
- [x] `gosec ./exp/paths/...` — 0 issues
- [x] `gofmt -s -l exp/paths/` — clean