### PR TITLE
feat(xdg): add StatePath helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,12 @@ HTTP client specifically designed for sending webhook payloads with retry logic,
 Zero-dependency application path resolver following platform conventions.
 
 **Features:**
-- XDG Base Directory spec compliance on Linux (`XDG_CONFIG_HOME`, `XDG_DATA_HOME`, etc.)
+- XDG Base Directory spec compliance on Linux (`XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `XDG_STATE_HOME`, `XDG_CACHE_HOME`, etc.)
 - macOS `~/Library/` conventions (Preferences, Application Support, Caches, Logs)
 - Windows `%LOCALAPPDATA%` / `%PROGRAMDATA%` support
 - User, System, and CustomHome scope types
 - Vendor prefix support
-- Config, Data, Cache, and Log path resolution
+- Config, Data, State, Cache, and Log path resolution
 - File lookup across priority-ordered directories
 
 **Example:**
@@ -127,6 +127,7 @@ scope := xdg.NewScope(xdg.User, "myapp")
 
 configPath, err := scope.ConfigPath("config.yaml")
 logPath, err := scope.LogPath("app.log")
+statePath, err := scope.StatePath("state.db")
 cacheDir, err := scope.CacheDir()
 
 // With vendor prefix

--- a/xdg/xdg.go
+++ b/xdg/xdg.go
@@ -234,6 +234,16 @@ func (s *Scope) logDir() (string, error) {
 	}
 }
 
+// stateDir resolves the base directory for application state files.
+// On Linux this honors the XDG Base Directory Specification's
+// XDG_STATE_HOME (default $HOME/.local/state, system /var/lib).
+// macOS has no dedicated state location; "Application Support" is the
+// idiomatic home for persistent application state and matches the
+// precedent set by dataDirs, so StatePath and DataPath share that root
+// on Darwin (callers should pick distinct filenames per concern).
+// On Windows, "State" is used as a subdir of %LOCALAPPDATA% (or
+// %PROGRAMDATA% for System) to keep state separate from Cache, Config,
+// and Logs.
 func (s *Scope) stateDir() (string, error) {
 	switch runtime.GOOS {
 	case "darwin":

--- a/xdg/xdg.go
+++ b/xdg/xdg.go
@@ -121,6 +121,15 @@ func (s *Scope) LogPath(filename string) (string, error) {
 	return filepath.Join(base, s.appPath(), filename), nil
 }
 
+// StatePath returns the full path for a state file.
+func (s *Scope) StatePath(filename string) (string, error) {
+	base, err := s.stateDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, s.appPath(), filename), nil
+}
+
 // LookupConfig returns paths to existing config files with the given name.
 func (s *Scope) LookupConfig(filename string) ([]string, error) {
 	dirs, err := s.ConfigDirs()
@@ -222,6 +231,17 @@ func (s *Scope) logDir() (string, error) {
 		return s.windowsDir("Logs")
 	default:
 		return s.xdgDir("", ".local/share", "/var/log")
+	}
+}
+
+func (s *Scope) stateDir() (string, error) {
+	switch runtime.GOOS {
+	case "darwin":
+		return s.darwinDir("Application Support")
+	case "windows":
+		return s.windowsDir("State")
+	default:
+		return s.xdgDir("XDG_STATE_HOME", ".local/state", "/var/lib")
 	}
 }
 

--- a/xdg/xdg_test.go
+++ b/xdg/xdg_test.go
@@ -95,6 +95,137 @@ func TestUserCacheDir(t *testing.T) {
 	}
 }
 
+func TestUserStatePath(t *testing.T) {
+	s := NewScope(User, "testapp")
+	p, err := s.StatePath("state.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(p, "testapp") {
+		t.Errorf("state path should contain app name: %s", p)
+	}
+	if !strings.HasSuffix(p, "state.db") {
+		t.Errorf("state path should end with filename: %s", p)
+	}
+}
+
+func TestStatePathXDGEnvOverride(t *testing.T) {
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		t.Skip("XDG env vars only apply on Linux/Unix")
+	}
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+
+	s := NewScope(User, "testapp")
+	p, err := s.StatePath("state.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := filepath.Join(dir, "testapp", "state.db")
+	if p != expected {
+		t.Errorf("state path = %q, want %q", p, expected)
+	}
+}
+
+func TestStatePathXDGEnvUnset(t *testing.T) {
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		t.Skip("XDG env vars only apply on Linux/Unix")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_STATE_HOME", "")
+
+	s := NewScope(User, "testapp")
+	p, err := s.StatePath("state.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := filepath.Join(home, ".local", "state", "testapp", "state.db")
+	if p != expected {
+		t.Errorf("state path = %q, want %q", p, expected)
+	}
+}
+
+func TestStatePathSystemScope(t *testing.T) {
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		t.Skip("Linux-specific system path")
+	}
+	s := NewScope(System, "testapp")
+	p, err := s.StatePath("state.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := "/var/lib/testapp/state.db"
+	if p != expected {
+		t.Errorf("state path = %q, want %q", p, expected)
+	}
+}
+
+func TestStatePathCustomHomeScope(t *testing.T) {
+	dir := t.TempDir()
+	s := NewCustomHomeScope(dir, "", "testapp")
+	p, err := s.StatePath("state.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(p, dir) {
+		t.Errorf("state path should start with %s: %s", dir, p)
+	}
+	if !strings.Contains(p, "testapp") {
+		t.Errorf("state path should contain app name: %s", p)
+	}
+	if !strings.HasSuffix(p, "state.db") {
+		t.Errorf("state path should end with filename: %s", p)
+	}
+}
+
+func TestStatePathVendorInPath(t *testing.T) {
+	s := NewVendorScope(User, "myvendor", "myapp")
+	p, err := s.StatePath("state.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(p, filepath.Join("myvendor", "myapp")) {
+		t.Errorf("state path should contain vendor/app: %s", p)
+	}
+	if !strings.HasSuffix(p, "state.db") {
+		t.Errorf("state path should end with filename: %s", p)
+	}
+}
+
+func TestStateDirReturnsExpectedBase(t *testing.T) {
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		t.Skip("Linux-specific base path")
+	}
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+
+	s := NewScope(User, "testapp")
+	base, err := s.stateDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if base != dir {
+		t.Errorf("stateDir = %q, want %q", base, dir)
+	}
+}
+
+func TestStatePathInvalidScopeType(t *testing.T) {
+	s := &Scope{Type: ScopeType(99), App: "testapp"}
+	_, err := s.StatePath("state.db")
+	if err == nil {
+		t.Error("expected error for invalid scope type")
+	}
+}
+
+func TestStatePathCustomHomeEmptyPath(t *testing.T) {
+	s := NewCustomHomeScope("", "", "testapp")
+	_, err := s.StatePath("state.db")
+	if err == nil {
+		t.Error("expected error for empty custom home")
+	}
+}
+
 func TestSystemPaths(t *testing.T) {
 	s := NewScope(System, "testapp")
 

--- a/xdg/xdg_test.go
+++ b/xdg/xdg_test.go
@@ -133,6 +133,8 @@ func TestStatePathXDGEnvUnset(t *testing.T) {
 	}
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	// Setting to "" simulates an unset variable: os.Getenv returns "" for
+	// both unset and set-to-empty, and xdgDir treats empty as unset.
 	t.Setenv("XDG_STATE_HOME", "")
 
 	s := NewScope(User, "testapp")


### PR DESCRIPTION
## Summary

Adds `StatePath(filename) (string, error)` and a private `stateDir()` on `*xdg.Scope`, mirroring the existing `LogPath`/`logDir` pattern. This gives callers a portable way to resolve a per-application state file path (e.g. `${XDG_STATE_HOME:-$HOME/.local/state}/<app>/<filename>` on Linux), filling the one gap in the existing data/config/cache/log helper set.

## Cross-platform handling

- **Linux** (and other Unix): `xdgDir("XDG_STATE_HOME", ".local/state", "/var/lib")`. Honors `XDG_STATE_HOME` for User scope, falls back to `$HOME/.local/state` per the XDG Base Directory Specification, and uses `/var/lib` for System scope.
- **Darwin**: `~/Library/Application Support/<app>/<filename>` for User/CustomHome, `/Library/Application Support/<app>/<filename>` for System. macOS does not define a separate "state" location; `Application Support` is the platform-idiomatic home for persistent application state and matches the existing `dataDirs` precedent in this package.
- **Windows**: `%LOCALAPPDATA%\State\<app>\<filename>` for User (with `~/AppData/Local` fallback), `%PROGRAMDATA%\State\...` for System. The `State` subdir keeps state separate from the existing `Cache`/`Config`/`Logs` subdirs used by the other helpers.

## Test coverage

All test cases use `t.Setenv` so environment mutations are scoped to the test:

- `TestUserStatePath` — basic User-scope sanity (path contains app, ends with filename).
- `TestStatePathXDGEnvOverride` — `XDG_STATE_HOME` set returns `$XDG_STATE_HOME/<app>/<filename>` (Linux only).
- `TestStatePathXDGEnvUnset` — `XDG_STATE_HOME` empty falls back to `$HOME/.local/state/<app>/<filename>` (Linux only).
- `TestStatePathSystemScope` — System scope returns `/var/lib/<app>/<filename>` (Linux only).
- `TestStatePathCustomHomeScope` — CustomHome scope is rooted at the supplied directory.
- `TestStatePathVendorInPath` — vendor-prefixed scope produces `<vendor>/<app>/<filename>`.
- `TestStateDirReturnsExpectedBase` — private `stateDir` alone returns the expected base directory (Linux only).
- `TestStatePathInvalidScopeType` — invalid scope type returns an error.
- `TestStatePathCustomHomeEmptyPath` — empty CustomHome returns an error.

## Quality gates

- `go vet ./xdg/...` — clean
- `go test -race -count=1 ./xdg/...` — clean
- `golangci-lint run --timeout=5m ./xdg/...` — 0 issues
- `gofmt -s -l xdg/` — clean
- `go mod tidy` — no diff

## Motivation

Unblocks mugatu's Phase 2c (state + silence store), which needs a portable default path for its bbolt state file (`${XDG_STATE_HOME:-$HOME/.local/state}/mugatu/state.db`). With this merged and a new `x` release tagged, mugatu can pin to the new version and proceed.

## Test plan

- [x] `go test -race -count=1 ./xdg/...` passes locally on Linux
- [x] `go vet ./xdg/...` clean
- [x] `golangci-lint run ./xdg/...` clean against the repo's v2 config
- [x] `go build ./...` for the whole module succeeds
- [ ] CI green on PR