### PR TITLE
fix(webhook): make retry backoff ctx-aware

### DIFF
--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -69,7 +69,11 @@ func postWithContext(ctx context.Context, client *http.Client, url string, heade
 }
 
 func SendWithContextAndRetry(ctx context.Context, retries int, delay time.Duration, client *http.Client, url string, headers map[string]string, data interface{}) error {
-	errs := make([]error, 0, retries)
+	capHint := retries
+	if capHint < 0 {
+		capHint = 0
+	}
+	errs := make([]error, 0, capHint)
 	for i := range retries {
 		if err := ctx.Err(); err != nil {
 			errs = append(errs, err)

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -69,16 +69,32 @@ func postWithContext(ctx context.Context, client *http.Client, url string, heade
 }
 
 func SendWithContextAndRetry(ctx context.Context, retries int, delay time.Duration, client *http.Client, url string, headers map[string]string, data interface{}) error {
-	var errs error
-	for range retries {
+	errs := make([]error, 0, retries)
+	for i := range retries {
+		if err := ctx.Err(); err != nil {
+			errs = append(errs, err)
+			return errors.Join(errs...)
+		}
 		err := SendWithContext(ctx, client, url, headers, data)
 		if err == nil {
 			return nil
 		}
-		errs = errors.Join(errs, err)
-		time.Sleep(delay)
+		errs = append(errs, err)
+		if i == retries-1 {
+			break
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			errs = append(errs, ctx.Err())
+			return errors.Join(errs...)
+		}
 	}
-	return errs
+	return errors.Join(errs...)
 }
 
 func SendWithContext(ctx context.Context, client *http.Client, url string, headers map[string]string, data interface{}) error {

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -3,9 +3,11 @@ package webhook
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -378,5 +380,158 @@ func TestSendWithContextAndRetryWithTimeout(t *testing.T) {
 
 	if !strings.Contains(err.Error(), "context deadline exceeded") {
 		t.Errorf("Expected timeout error, got: %v", err)
+	}
+}
+
+func TestSendWithContextAndRetry_CtxCancelDuringDelay(t *testing.T) {
+	payload := testPayload{Message: "cancel during delay", ID: 201}
+
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("Server Error"))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Cancel shortly after the first attempt completes, while the retry loop
+	// is sleeping on the 100ms backoff. Without a ctx-aware backoff, the call
+	// would continue sleeping the full delay.
+	go func() {
+		for attempts.Load() < 1 {
+			time.Sleep(time.Millisecond)
+		}
+		time.Sleep(5 * time.Millisecond)
+		cancel()
+	}()
+
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	start := time.Now()
+	err := SendWithContextAndRetry(ctx, 5, 100*time.Millisecond, client, server.URL, nil, payload)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Expected errors.Is(err, context.Canceled), got: %v", err)
+	}
+	// First attempt + a few ms before cancel + tiny wakeup slack. Must be
+	// well under the single 100ms delay window, and far under 5*100ms.
+	if elapsed > 80*time.Millisecond {
+		t.Errorf("Expected prompt return after cancel, took %v", elapsed)
+	}
+	if got := attempts.Load(); got != 1 {
+		t.Errorf("Expected exactly 1 attempt before cancel, got %d", got)
+	}
+}
+
+func TestSendWithContextAndRetry_CtxDeadlineDuringDelay(t *testing.T) {
+	payload := testPayload{Message: "deadline during delay", ID: 202}
+
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("Server Error"))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	start := time.Now()
+	err := SendWithContextAndRetry(ctx, 5, 100*time.Millisecond, client, server.URL, nil, payload)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("Expected errors.Is(err, context.DeadlineExceeded), got: %v", err)
+	}
+	// 5 retries * 100ms delay would be 500ms+. With a ctx-aware backoff we
+	// should return near the 150ms deadline.
+	if elapsed > 250*time.Millisecond {
+		t.Errorf("Expected return near deadline (150ms), took %v", elapsed)
+	}
+}
+
+func TestSendWithContextAndRetry_SucceedsAfterRetry(t *testing.T) {
+	payload := testPayload{Message: "succeeds after retry", ID: 203}
+
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("Server Error"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	delay := 20 * time.Millisecond
+	start := time.Now()
+	err := SendWithContextAndRetry(ctx, 5, delay, client, server.URL, nil, payload)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("Expected success after one retry, got: %v", err)
+	}
+	if got := attempts.Load(); got != 2 {
+		t.Errorf("Expected 2 attempts, got %d", got)
+	}
+	if elapsed < delay {
+		t.Errorf("Expected at least one %v backoff between attempts, elapsed %v", delay, elapsed)
+	}
+}
+
+func TestSendWithContextAndRetry_ExhaustsRetries(t *testing.T) {
+	payload := testPayload{Message: "exhausts retries", ID: 204}
+
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("Server Error"))
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	const retries = 4
+	err := SendWithContextAndRetry(ctx, retries, 5*time.Millisecond, client, server.URL, nil, payload)
+	if err == nil {
+		t.Fatal("Expected error after exhausting retries, got nil")
+	}
+	if got := attempts.Load(); got != int32(retries) {
+		t.Errorf("Expected %d attempts, got %d", retries, got)
+	}
+
+	// errors.Join wraps each attempt's error; Unwrap() []error exposes them.
+	u, ok := err.(interface{ Unwrap() []error })
+	if !ok {
+		t.Fatalf("Expected joined error with Unwrap() []error, got %T: %v", err, err)
+	}
+	joined := u.Unwrap()
+	if len(joined) != retries {
+		t.Errorf("Expected %d joined errors, got %d", retries, len(joined))
+	}
+	for i, e := range joined {
+		if !strings.Contains(e.Error(), "HTTP status code: 500") {
+			t.Errorf("joined[%d] = %v, want 500 status", i, e)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

`SendWithContextAndRetry` used `time.Sleep(delay)` between attempts, which is not cancellable by the caller's `ctx`. A caller that does `ctx, cancel := context.WithCancel(parent); defer cancel()` (or `WithTimeout`) and cancels during a backoff window will still sit in `time.Sleep` for the full `delay`, extending shutdown windows past their deadlines.

This change replaces the sleep with a ctx-aware backoff and guards the top of the loop against an already-cancelled ctx so we don't issue a doomed request between attempts:

```go
timer := time.NewTimer(delay)
select {
case <-timer.C:
case <-ctx.Done():
    if !timer.Stop() {
        <-timer.C
    }
    errs = append(errs, ctx.Err())
    return errors.Join(errs...)
}
```

When ctx fires during the delay, the returned error is `errors.Join` of the accumulated attempt errors plus `ctx.Err()`, so callers can use `errors.Is(err, context.Canceled)` / `errors.Is(err, context.DeadlineExceeded)` to detect why we bailed. `SendWithContext` already inherits ctx cancellation via `http.NewRequestWithContext`, so no change was needed there.

Per-attempt errors are now accumulated into a `[]error` and joined once at the end, so `Unwrap() []error` on the returned error yields one entry per failed attempt rather than a nested tree from repeated `errors.Join(errs, err)` calls.

## Changes

- `webhook/webhook.go`: `SendWithContextAndRetry` uses `time.NewTimer` + `select` on `ctx.Done()`; early `ctx.Err()` check at loop top; no sleep after the final attempt; slice-based error accumulation.
- `webhook/webhook_test.go`: four new tests covering cancel-during-delay, deadline-during-delay, success-after-retry, and exhausted retries (Unwrap count + content assertions).

## Downstream

Surfaces in `github.com/heatxsink/mugatu` PR #12 (Phase 4b) as a shutdown-latency concern: the mugatu daemon cancels a shared ctx on SIGTERM and expects outbound webhook senders to unwind promptly; with the old `time.Sleep`, shutdown could be held up by the full `retries * delay` window.

## Test plan

- [x] `go test -race -timeout=60s ./webhook/...` passes
- [x] `go test -race -timeout=60s ./...` passes
- [x] `go vet ./webhook/...` clean
- [x] `golangci-lint run --timeout=5m ./webhook/...` clean (0 issues)
- [x] `gofmt -s -l ./webhook/` clean
- [x] New cancel-during-delay test returns in <80ms vs the 500ms worst case of the old behavior
- [x] New deadline-during-delay test returns near the 150ms deadline vs 500ms worst case