### PR TITLE
healthz: make *Healthz the http.Handler; fix race + format tolerance

### DIFF
--- a/exp/http/healthz/healthz.go
+++ b/exp/http/healthz/healthz.go
@@ -1,12 +1,15 @@
 package healthz
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/heatxsink/x/exp/http/responses"
 )
 
+// Healthz is a small JSON probe describing what is currently running.
+// It satisfies http.Handler; register it with mux.Handle directly.
 type Healthz struct {
 	Version   string `json:"version"`
 	BuildDate string `json:"build_date"`
@@ -14,18 +17,40 @@ type Healthz struct {
 	Hash      string `json:"commit_hash"`
 }
 
-func (h *Healthz) Handler() http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t, _ := time.Parse("2006-01-02T15:04:05Z0700", h.BuildDate)
-		h.TimeSince = time.Since(t).String()
-		responses.OK(w, &h)
-	})
+// buildDateFormats lists the timestamp layouts the handler will accept
+// for BuildDate, in priority order. RFC3339 is the canonical form;
+// the second entry is retained for callers still emitting the legacy
+// pre-RFC3339 layout (no colon in the timezone offset).
+var buildDateFormats = []string{
+	time.RFC3339,
+	"2006-01-02T15:04:05Z0700",
 }
 
-func (h *Healthz) ResponseHandler() http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t, _ := time.Parse("2006-01-02T15:04:05Z0700", h.BuildDate)
-		h.TimeSince = time.Since(t).String()
-		responses.OK(w, &h)
-	})
+func parseBuildDate(s string) (time.Time, error) {
+	for _, layout := range buildDateFormats {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("healthz: unrecognised BuildDate %q", s)
 }
+
+// ServeHTTP renders Healthz as a JSON response. The handler builds a
+// fresh response value per request rather than mutating h, so concurrent
+// requests do not race on TimeSince.
+func (h *Healthz) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	resp := Healthz{
+		Version:   h.Version,
+		BuildDate: h.BuildDate,
+		Hash:      h.Hash,
+	}
+	if t, err := parseBuildDate(h.BuildDate); err == nil {
+		resp.TimeSince = time.Since(t).String()
+	}
+	responses.OK(w, resp)
+}
+
+// ResponseHandler returns h.
+//
+// Deprecated: register *Healthz directly as an http.Handler instead.
+func (h *Healthz) ResponseHandler() http.Handler { return h }

--- a/exp/http/healthz/healthz_test.go
+++ b/exp/http/healthz/healthz_test.go
@@ -1,0 +1,157 @@
+package healthz
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// envelope mirrors the shape responses.OK wraps around the payload.
+type envelope struct {
+	StatusCode int      `json:"status_code"`
+	StatusText string   `json:"status_text"`
+	Data       *Healthz `json:"data"`
+}
+
+func decodeBody(t *testing.T, w *httptest.ResponseRecorder) envelope {
+	t.Helper()
+	var got envelope
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if got.Data == nil {
+		t.Fatalf("data field missing from response: %s", w.Body.String())
+	}
+	return got
+}
+
+func TestServeHTTP_PopulatesFields(t *testing.T) {
+	h := &Healthz{
+		Version:   "v1.2.3",
+		BuildDate: time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339),
+		Hash:      "abc1234",
+	}
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	got := decodeBody(t, w)
+	if got.Data.Version != "v1.2.3" || got.Data.Hash != "abc1234" {
+		t.Errorf("Version/Hash = %q/%q, want v1.2.3/abc1234", got.Data.Version, got.Data.Hash)
+	}
+	if got.Data.TimeSince == "" {
+		t.Errorf("TimeSince empty; want non-empty for valid BuildDate")
+	}
+}
+
+func TestServeHTTP_AcceptsRFC3339(t *testing.T) {
+	h := &Healthz{BuildDate: "2026-05-01T11:14:33Z"}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	got := decodeBody(t, w)
+	if got.Data.TimeSince == "" {
+		t.Errorf("RFC3339 BuildDate should produce a non-empty TimeSince")
+	}
+}
+
+func TestServeHTTP_AcceptsLegacyFormat(t *testing.T) {
+	h := &Healthz{BuildDate: "2026-05-01T11:14:33-0700"}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	got := decodeBody(t, w)
+	if got.Data.TimeSince == "" {
+		t.Errorf("legacy BuildDate should produce a non-empty TimeSince")
+	}
+}
+
+func TestServeHTTP_UnparsableBuildDateLeavesTimeSinceEmpty(t *testing.T) {
+	h := &Healthz{BuildDate: "garbage"}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	got := decodeBody(t, w)
+	if got.Data.TimeSince != "" {
+		t.Errorf("TimeSince = %q, want empty for unparsable BuildDate", got.Data.TimeSince)
+	}
+}
+
+// TestServeHTTP_DoesNotMutateReceiver guards the race fix: prior to the
+// rewrite the handler wrote h.TimeSince on every request. After: h is
+// observed unchanged across requests.
+func TestServeHTTP_DoesNotMutateReceiver(t *testing.T) {
+	h := &Healthz{
+		Version:   "v1.0.0",
+		BuildDate: time.Now().Add(-time.Hour).UTC().Format(time.RFC3339),
+	}
+	if h.TimeSince != "" {
+		t.Fatalf("precondition: TimeSince should start empty, got %q", h.TimeSince)
+	}
+
+	for i := 0; i < 3; i++ {
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+	}
+	if h.TimeSince != "" {
+		t.Errorf("TimeSince mutated to %q; handler must not write to receiver", h.TimeSince)
+	}
+}
+
+// TestServeHTTP_ConcurrentRequests is the explicit race regression. Run
+// with `go test -race`. Prior to the rewrite, concurrent handlers raced
+// on h.TimeSince.
+func TestServeHTTP_ConcurrentRequests(t *testing.T) {
+	h := &Healthz{
+		Version:   "v1.0.0",
+		BuildDate: time.Now().Add(-time.Minute).UTC().Format(time.RFC3339),
+	}
+
+	var wg sync.WaitGroup
+	const n = 64
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+			if w.Code != http.StatusOK {
+				t.Errorf("status = %d, want 200", w.Code)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestSatisfiesHTTPHandler(t *testing.T) {
+	var _ http.Handler = (*Healthz)(nil)
+}
+
+func TestResponseHandler_ReturnsReceiver(t *testing.T) {
+	h := &Healthz{Version: "v1"}
+	got := h.ResponseHandler()
+	hh, ok := got.(*Healthz)
+	if !ok {
+		t.Fatalf("ResponseHandler returned %T, want *Healthz", got)
+	}
+	if hh != h {
+		t.Errorf("ResponseHandler did not return the receiver")
+	}
+}
+
+func TestParseBuildDate_ErrorContainsInput(t *testing.T) {
+	_, err := parseBuildDate("not-a-time")
+	if err == nil {
+		t.Fatal("expected error for unparsable input, got nil")
+	}
+	if !strings.Contains(err.Error(), "not-a-time") {
+		t.Errorf("error %q should contain offending input", err)
+	}
+}


### PR DESCRIPTION
## Summary

Three fixes to ` + "`exp/http/healthz`" + `, wrapped in a small API tightening:

- ** ` + "`*Healthz`" + ` now satisfies ` + "`http.Handler`" + ` directly.** Callers register it with ` + "`mux.Handle(p, hh)`" + ` instead of ` + "`mux.Handle(p, hh.Handler())`" + `. Standard Go pattern.
- **Race fix.** The previous ` + "`Handler`" + `/` + "`ResponseHandler`" + ` mutated ` + "`h.TimeSince`" + ` on every request -- concurrent ` + "`/healthz`" + ` hits raced on that field. ` + "`ServeHTTP`" + ` now builds a fresh response value per request and never writes to the receiver.
- **Format tolerance.** The old ` + "`time.Parse`" + ` hardcoded ` + "`\"2006-01-02T15:04:05Z0700\"`" + ` (no colon in the offset), which fails to parse anything emitted by ` + "`time.RFC3339`" + `. Callers passing RFC3339 (e.g. buoy via ` + "`bi.RFC3339()`" + `) silently ended up with a zero time and ` + "`TimeSince`" + ` of *~2026 years*. ` + "`parseBuildDate`" + ` now tries ` + "`time.RFC3339`" + ` first, falls back to the legacy layout. Existing callers keep working; new callers can use the standard format.
- **Method dedupe.** ` + "`Handler()`" + ` and ` + "`ResponseHandler()`" + ` were byte-identical. ` + "`Handler()`" + ` is **removed** (only two known callers, both heatxsink-owned, trivial migration to passing ` + "`*Healthz`" + ` directly). ` + "`ResponseHandler()`" + ` is **retained as a deprecated forwarder** so the broader callsite surface (querystory + others) compiles unchanged.

## API surface

| Method                     | Before                | After                                            |
|----------------------------|-----------------------|--------------------------------------------------|
| ` + "`ServeHTTP(w, r)`" + `        | (n/a)                 | new -- canonical entry point                     |
| ` + "`Handler() http.Handler`" + ` | duplicate-body method | **removed**                                       |
| ` + "`ResponseHandler() http.Handler`" + ` | duplicate-body method | one-line forwarder, ` + "`// Deprecated:`" + `       |

## Caller impact

- **querystory** (qs-app, qs-app-two/three/four, qsi-automation*, brennan): all use ` + "`ResponseHandler()`" + `. Continue compiling unchanged. Their golangci-lint runs use ` + "`--new-from-rev=origin/main`" + `, so the deprecation only flags *net-new* call sites in *future* PRs (which is the desired nudge).
- **buoy, mugatu**: use ` + "`Handler()`" + `. **Will fail to compile against tip-of-x** until follow-up PRs migrate them to passing ` + "`*Healthz`" + ` directly. Owned, scheduled.
- **lovethat.lol, hwebhookrouter, dd-hud, third_party**: ` + "`ResponseHandler()`" + ` or unaffected. Continue compiling.

## Test plan

- [x] ` + "`go build ./...`" + ` clean.
- [x] ` + "`go test -race ./exp/http/healthz/...`" + ` green.
- [x] ` + "`golangci-lint run ./exp/http/healthz/...`" + ` 0 issues.
- [x] ` + "`TestServeHTTP_DoesNotMutateReceiver`" + ` -- guards the race fix.
- [x] ` + "`TestServeHTTP_ConcurrentRequests`" + ` -- 64-goroutine fanout, race-detector regression.
- [x] ` + "`TestServeHTTP_AcceptsRFC3339`" + ` and ` + "`TestServeHTTP_AcceptsLegacyFormat`" + ` -- format tolerance.
- [x] ` + "`TestServeHTTP_UnparsableBuildDateLeavesTimeSinceEmpty`" + ` -- replaces the silent-garbage behaviour.
- [x] ` + "`TestSatisfiesHTTPHandler`" + ` -- compile-time check that ` + "`*Healthz`" + ` implements ` + "`http.Handler`" + `.
- [ ] CI green.

## Follow-ups (separate PRs, after this is tagged)

1. ` + "`heatxsink/buoy`" + `: bump x, ` + "`hh.Handler()`" + ` -> ` + "`hh`" + `.
2. ` + "`heatxsink/mugatu`" + `: bump x, ` + "`h.Handler().ServeHTTP(w, r)`" + ` -> ` + "`h.ServeHTTP(w, r)`" + `.
3. ` + "`heatxsink/hud`" + `: bump x, wire ` + "`mux.Handle(\"GET /healthz\", hh)`" + ` as part of the cmd/internal/assets layout PR.