### PR TITLE
feat(exp/logger): configurable level via WithLevel option, default Info

### DIFF
--- a/exp/logger/logger.go
+++ b/exp/logger/logger.go
@@ -14,6 +14,30 @@ type contextKey string
 
 const loggerKey contextKey = "zap-logger"
 
+// Option configures a logger constructed by Get, File, or StdErr.
+type Option func(*config)
+
+type config struct {
+	level zapcore.LevelEnabler
+}
+
+func defaultConfig() *config {
+	return &config{level: zapcore.InfoLevel}
+}
+
+func resolve(opts []Option) *config {
+	c := defaultConfig()
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// WithLevel sets the minimum level the logger will emit. Defaults to InfoLevel.
+func WithLevel(l zapcore.LevelEnabler) Option {
+	return func(c *config) { c.level = l }
+}
+
 func WithLogger(slogger *zap.Logger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -31,39 +55,40 @@ func FromContext(ctx context.Context) *zap.Logger {
 	if logger, ok := ctx.Value(loggerKey).(*zap.Logger); ok {
 		return logger
 	}
-	return initLoggerToStdErr()
+	return initLoggerToStdErr(defaultConfig())
 }
 
 func FromRequest(r *http.Request) *zap.Logger {
 	return FromContext(r.Context())
 }
 
-func Get(filename string, fromStdError bool) *zap.Logger {
+func Get(filename string, fromStdError bool, opts ...Option) *zap.Logger {
+	c := resolve(opts)
 	if fromStdError {
-		return initLoggerToStdErr()
+		return initLoggerToStdErr(c)
 	}
-	return initLoggerToFile(filename)
+	return initLoggerToFile(filename, c)
 }
 
-func File(filename string) *zap.Logger {
-	return initLoggerToFile(filename)
+func File(filename string, opts ...Option) *zap.Logger {
+	return initLoggerToFile(filename, resolve(opts))
 }
 
-func StdErr() *zap.Logger {
-	return initLoggerToStdErr()
+func StdErr(opts ...Option) *zap.Logger {
+	return initLoggerToStdErr(resolve(opts))
 }
 
-func initLoggerToStdErr() *zap.Logger {
+func initLoggerToStdErr(c *config) *zap.Logger {
 	stderrSyncer := zapcore.Lock(os.Stderr)
 	encoderConfig := zap.NewProductionEncoderConfig()
 	encoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	encoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
 	encoder := zapcore.NewConsoleEncoder(encoderConfig)
-	core := zapcore.NewCore(encoder, stderrSyncer, zapcore.DebugLevel)
+	core := zapcore.NewCore(encoder, stderrSyncer, c.level)
 	return zap.New(core, zap.AddCaller())
 }
 
-func initLoggerToFile(filename string) *zap.Logger {
+func initLoggerToFile(filename string, c *config) *zap.Logger {
 	lumberJackLogger := &lumberjack.Logger{
 		Filename:   filename,
 		MaxSize:    50, // mb
@@ -76,6 +101,6 @@ func initLoggerToFile(filename string) *zap.Logger {
 	encoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	encoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
 	encoder := zapcore.NewConsoleEncoder(encoderConfig)
-	core := zapcore.NewCore(encoder, writerSyncer, zapcore.DebugLevel)
+	core := zapcore.NewCore(encoder, writerSyncer, c.level)
 	return zap.New(core, zap.AddCaller())
 }

--- a/exp/logger/logger_test.go
+++ b/exp/logger/logger_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestGet(t *testing.T) {
-	t.Run("stderr logger", func(t *testing.T) {
+	t.Run("stderr logger defaults to info", func(t *testing.T) {
 		logger := Get("", true)
 		if logger == nil {
 			t.Error("Expected logger, got nil")
@@ -29,12 +29,22 @@ func TestGet(t *testing.T) {
 			t.Error("Expected core, got nil")
 		}
 
-		if !core.Enabled(zapcore.DebugLevel) {
-			t.Error("Expected debug level to be enabled")
+		if core.Enabled(zapcore.DebugLevel) {
+			t.Error("Expected debug level to be disabled by default")
+		}
+		if !core.Enabled(zapcore.InfoLevel) {
+			t.Error("Expected info level to be enabled by default")
 		}
 	})
 
-	t.Run("file logger", func(t *testing.T) {
+	t.Run("stderr logger honors WithLevel", func(t *testing.T) {
+		logger := Get("", true, WithLevel(zapcore.DebugLevel))
+		if !logger.Core().Enabled(zapcore.DebugLevel) {
+			t.Error("Expected debug level to be enabled when WithLevel(DebugLevel) is passed")
+		}
+	})
+
+	t.Run("file logger defaults to info", func(t *testing.T) {
 		tempDir := t.TempDir()
 		logFile := filepath.Join(tempDir, "test.log")
 
@@ -48,8 +58,11 @@ func TestGet(t *testing.T) {
 			t.Error("Expected core, got nil")
 		}
 
-		if !core.Enabled(zapcore.DebugLevel) {
-			t.Error("Expected debug level to be enabled")
+		if core.Enabled(zapcore.DebugLevel) {
+			t.Error("Expected debug level to be disabled by default")
+		}
+		if !core.Enabled(zapcore.InfoLevel) {
+			t.Error("Expected info level to be enabled by default")
 		}
 
 		logger.Info("test message")
@@ -75,8 +88,11 @@ func TestFile(t *testing.T) {
 		t.Error("Expected core, got nil")
 	}
 
-	if !core.Enabled(zapcore.DebugLevel) {
-		t.Error("Expected debug level to be enabled")
+	if core.Enabled(zapcore.DebugLevel) {
+		t.Error("Expected debug level to be disabled by default")
+	}
+	if !core.Enabled(zapcore.InfoLevel) {
+		t.Error("Expected info level to be enabled by default")
 	}
 
 	logger.Info("test file message")
@@ -98,13 +114,16 @@ func TestStdErr(t *testing.T) {
 		t.Error("Expected core, got nil")
 	}
 
-	if !core.Enabled(zapcore.DebugLevel) {
-		t.Error("Expected debug level to be enabled")
+	if core.Enabled(zapcore.DebugLevel) {
+		t.Error("Expected debug level to be disabled by default")
+	}
+	if !core.Enabled(zapcore.InfoLevel) {
+		t.Error("Expected info level to be enabled by default")
 	}
 }
 
 func TestInitLoggerToStdErr(t *testing.T) {
-	logger := initLoggerToStdErr()
+	logger := initLoggerToStdErr(defaultConfig())
 	if logger == nil {
 		t.Error("Expected logger, got nil")
 	}
@@ -114,8 +133,8 @@ func TestInitLoggerToStdErr(t *testing.T) {
 		t.Error("Expected core, got nil")
 	}
 
-	if !core.Enabled(zapcore.DebugLevel) {
-		t.Error("Expected debug level to be enabled")
+	if core.Enabled(zapcore.DebugLevel) {
+		t.Error("Expected debug level to be disabled at default")
 	}
 
 	if !core.Enabled(zapcore.InfoLevel) {
@@ -135,7 +154,7 @@ func TestInitLoggerToFile(t *testing.T) {
 	tempDir := t.TempDir()
 	logFile := filepath.Join(tempDir, "test_init.log")
 
-	logger := initLoggerToFile(logFile)
+	logger := initLoggerToFile(logFile, defaultConfig())
 	if logger == nil {
 		t.Error("Expected logger, got nil")
 	}
@@ -145,8 +164,8 @@ func TestInitLoggerToFile(t *testing.T) {
 		t.Error("Expected core, got nil")
 	}
 
-	if !core.Enabled(zapcore.DebugLevel) {
-		t.Error("Expected debug level to be enabled")
+	if !core.Enabled(zapcore.InfoLevel) {
+		t.Error("Expected info level to be enabled")
 	}
 
 	logger.Info("test init message")
@@ -247,8 +266,8 @@ func TestFromContext(t *testing.T) {
 		if logger == nil {
 			t.Fatal("Expected fallback logger, got nil")
 		}
-		if !logger.Core().Enabled(zapcore.DebugLevel) {
-			t.Error("Expected debug level to be enabled on fallback logger")
+		if !logger.Core().Enabled(zapcore.InfoLevel) {
+			t.Error("Expected info level to be enabled on fallback logger")
 		}
 	})
 
@@ -259,8 +278,8 @@ func TestFromContext(t *testing.T) {
 		if logger == nil {
 			t.Fatal("Expected fallback logger, got nil")
 		}
-		if !logger.Core().Enabled(zapcore.DebugLevel) {
-			t.Error("Expected debug level to be enabled on fallback logger")
+		if !logger.Core().Enabled(zapcore.InfoLevel) {
+			t.Error("Expected info level to be enabled on fallback logger")
 		}
 	})
 }
@@ -304,8 +323,8 @@ func TestFromRequest(t *testing.T) {
 			t.Error("Expected core, got nil")
 		}
 
-		if !core.Enabled(zapcore.DebugLevel) {
-			t.Error("Expected debug level to be enabled on fallback logger")
+		if !core.Enabled(zapcore.InfoLevel) {
+			t.Error("Expected info level to be enabled on fallback logger")
 		}
 	})
 
@@ -324,8 +343,8 @@ func TestFromRequest(t *testing.T) {
 			t.Error("Expected core, got nil")
 		}
 
-		if !core.Enabled(zapcore.DebugLevel) {
-			t.Error("Expected debug level to be enabled on fallback logger")
+		if !core.Enabled(zapcore.InfoLevel) {
+			t.Error("Expected info level to be enabled on fallback logger")
 		}
 	})
 }
@@ -451,7 +470,7 @@ func TestLoggerLevels(t *testing.T) {
 	tempDir := t.TempDir()
 	logFile := filepath.Join(tempDir, "levels.log")
 
-	logger := File(logFile)
+	logger := File(logFile, WithLevel(zapcore.DebugLevel))
 
 	logger.Debug("debug message")
 	logger.Info("info message")
@@ -482,5 +501,33 @@ func TestLoggerLevels(t *testing.T) {
 
 	if !strings.Contains(logContent, "error message") {
 		t.Error("Expected error message in log file")
+	}
+}
+
+func TestDefaultLevelDropsDebug(t *testing.T) {
+	tempDir := t.TempDir()
+	logFile := filepath.Join(tempDir, "default_level.log")
+
+	logger := File(logFile)
+
+	logger.Debug("debug message")
+	logger.Info("info message")
+	_ = logger.Sync()
+
+	time.Sleep(100 * time.Millisecond)
+
+	content, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("Failed to read log file: %v", err)
+	}
+
+	logContent := string(content)
+
+	if strings.Contains(logContent, "debug message") {
+		t.Error("Debug message should be filtered out at default (Info) level")
+	}
+
+	if !strings.Contains(logContent, "info message") {
+		t.Error("Info message should be present at default (Info) level")
 	}
 }


### PR DESCRIPTION
## Summary
- Add variadic \`Option\` pattern to \`Get\`, \`File\`, \`StdErr\`; ship \`WithLevel\` for callers that need a non-default threshold.
- Flip default level from \`zapcore.DebugLevel\` to \`zapcore.InfoLevel\`. Hardcoded debug meant every consumer emitted debug-and-up in production with no way to change it.
- Backwards-compatible signatures: every existing call site across consumers (~40 repos) compiles unchanged.

## Behavior change to be aware of
The only consumer in this org that calls \`.Debug()\` is \`haq/main.go:665\` (one line confirming MQTT topic subscriptions). After this lands, that line stops emitting unless \`haq\` opts in with \`logger.Get(file, stderr, logger.WithLevel(zapcore.DebugLevel))\`. Subscription confirmations are arguably noise that belongs at debug — flagging it so a follow-up in \`haq\` can be made if the line is wanted back.

## Test plan
- [x] \`go test ./exp/logger/...\` passes
- [x] \`go vet ./exp/logger/...\` clean
- [x] \`go build ./...\` clean
- [x] New test \`TestDefaultLevelDropsDebug\` confirms default-Info filters debug output
- [x] New \`TestGet\` subtest confirms \`WithLevel(DebugLevel)\` enables debug
- [x] Existing tests updated from \"Debug enabled\" assertions to \"Info enabled, Debug disabled\"