### PR TITLE
systemd+loom: user-mode services (systemctl --user, ~/.local/bin)

### DIFF
--- a/exp/loom/loom.go
+++ b/exp/loom/loom.go
@@ -20,16 +20,43 @@ type Loom struct {
 	port        string
 	destination string
 	serviceName string
+	// userMode flips every system-affecting operation to the per-user
+	// equivalent: systemctl --user instead of sudo systemctl,
+	// ~/.config/systemd/user/ instead of /etc/systemd/system/, and
+	// ~/.local/{bin,etc,log} instead of /opt/<service>/{bin,etc,log}.
+	// No sudo is invoked in user mode -- the remote login user owns
+	// every path touched.
+	userMode bool
 }
 
+// New returns a Loom configured for system-level service management:
+// units installed under /etc/systemd/system/, binary placed under
+// /opt/<serviceName>/bin/, and `sudo systemctl <cmd>` for service
+// control. The remote user must be able to sudo without a password.
 func New(serviceName string, useAgent bool) (*Loom, error) {
-	err := dotenv.Load()
-	if err != nil {
+	return load(serviceName, useAgent, false)
+}
+
+// NewUser returns a Loom configured for per-user service management:
+// units under ~/.config/systemd/user/, binary under ~/.local/bin/,
+// and `systemctl --user <cmd>` for service control. No sudo. The
+// remote login user owns and manages everything.
+//
+// For lasting `--user` services that survive logout, the operator
+// should `loginctl enable-linger` on the remote once -- not loom's
+// job, but documented in the project README.
+func NewUser(serviceName string, useAgent bool) (*Loom, error) {
+	return load(serviceName, useAgent, true)
+}
+
+func load(serviceName string, useAgent, userMode bool) (*Loom, error) {
+	if err := dotenv.Load(); err != nil {
 		return nil, err
 	}
 	return &Loom{
 		serviceName: serviceName,
 		useAgent:    useAgent,
+		userMode:    userMode,
 		login:       os.Getenv("LOOM_SSH_LOGIN"),
 		password:    os.Getenv("LOOM_SSH_PASSWORD"),
 		hostname:    os.Getenv("LOOM_SSH_HOSTNAME"),
@@ -83,8 +110,53 @@ func (l *Loom) Upload(ctx context.Context, src, dst string) error {
 }
 
 func (l *Loom) Service(ctx context.Context, command string) error {
+	if l.userMode {
+		cmd := fmt.Sprintf("systemctl --user %s %s", command, l.serviceName)
+		return l.Remote(ctx, cmd)
+	}
 	cmd := fmt.Sprintf("sudo systemctl %s %s", command, l.serviceName)
 	return l.Remote(ctx, cmd)
+}
+
+// systemdUnitDir is the directory the generated unit lands in --
+// /etc/systemd/system/ for system mode, ~/.config/systemd/user/ for
+// user mode.
+func (l *Loom) systemdUnitDir() string {
+	if l.userMode {
+		return "$HOME/.config/systemd/user"
+	}
+	return "/etc/systemd/system"
+}
+
+// installPrefix is the parent of bin/etc/log on the remote in
+// system mode (/opt/<service>). In user mode the layout is XDG:
+// the binary goes to $HOME/.local/bin/<service>, config lives at
+// $HOME/.config/<service>/ owned by the application, and logs are
+// captured by journald via systemd -- no etc/log dirs are created.
+// installPrefix is unused in user mode; binPath does the right
+// thing per mode.
+func (l *Loom) installPrefix() string {
+	return fmt.Sprintf("/opt/%s", l.serviceName)
+}
+
+// binPath is the final destination of the deployed binary.
+//
+//	system:  /opt/<service>/bin/<service>
+//	user:    $HOME/.local/bin/<service>
+func (l *Loom) binPath() string {
+	if l.userMode {
+		return "$HOME/.local/bin/" + l.serviceName
+	}
+	return fmt.Sprintf("/opt/%s/bin/%s", l.serviceName, l.serviceName)
+}
+
+// sudoPrefix is "sudo " for system mode, empty for user mode --
+// every shell-out that touches a privileged path uses this.
+func (l *Loom) sudoPrefix() string {
+	if l.userMode {
+		return ""
+	}
+	return "sudo "
 }
 
 func (l *Loom) ServiceFile(execStart string) (string, error) {
@@ -102,22 +174,56 @@ func (l *Loom) UploadToDestination(ctx context.Context, filename string) error {
 	return l.Upload(ctx, source, destination)
 }
 
+// MoveToOptBin moves the just-uploaded binary into its install
+// path. The method name is a holdover from the system-mode-only
+// past; it now does the right thing per mode (see binPath).
 func (l *Loom) MoveToOptBin(ctx context.Context) error {
-	cmd := fmt.Sprintf("sudo mv -f %s /opt/%s/bin/%s", l.serviceName, l.serviceName, l.serviceName)
+	cmd := fmt.Sprintf("%smv -f %s %s",
+		l.sudoPrefix(), l.serviceName, l.binPath())
 	return l.Remote(ctx, cmd)
 }
 
+// Setup installs everything a fresh remote needs:
+//
+//	system mode:
+//	  - uploads serviceFile + binary to staging destination
+//	  - sudo mv serviceFile -> /etc/systemd/system/
+//	  - sudo mkdir -p /opt/<service>/{bin,etc,log}
+//	  - sudo mv binary -> /opt/<service>/bin/
+//	  - sudo systemctl enable <service>
+//
+//	user mode:
+//	  - uploads serviceFile + binary to staging destination
+//	  - mkdir -p ~/.config/systemd/user ~/.local/bin
+//	  - mv serviceFile -> ~/.config/systemd/user/
+//	  - mv binary -> ~/.local/bin/<service>
+//	  - systemctl --user enable <service>
+//	  (no etc/log -- the daemon owns config via XDG paths and logs
+//	   land in the journal via systemd's stdout capture)
+//
+// In user mode no sudo is invoked. In system mode the remote user
+// must be able to sudo without a password.
 func (l *Loom) Setup(ctx context.Context, serviceFile string) error {
 	if err := l.UploadToDestination(ctx, serviceFile); err != nil {
 		return err
 	}
-	cmd := fmt.Sprintf("sudo mv -f %s/%s /etc/systemd/system/%s", l.destination, serviceFile, serviceFile)
-	if err := l.Remote(ctx, cmd); err != nil {
+	if l.userMode {
+		mkdirCmd := fmt.Sprintf("mkdir -p %s $HOME/.local/bin", l.systemdUnitDir())
+		if err := l.Remote(ctx, mkdirCmd); err != nil {
+			return err
+		}
+	}
+	mvCmd := fmt.Sprintf("%smv -f %s/%s %s/%s",
+		l.sudoPrefix(), l.destination, serviceFile, l.systemdUnitDir(), serviceFile)
+	if err := l.Remote(ctx, mvCmd); err != nil {
 		return err
 	}
-	cmd = fmt.Sprintf("sudo mkdir -p /opt/%s/{bin,etc,log}", l.serviceName)
-	if err := l.Remote(ctx, cmd); err != nil {
-		return err
+	if !l.userMode {
+		mkdirCmd := fmt.Sprintf("sudo mkdir -p %s/bin %s/etc %s/log",
+			l.installPrefix(), l.installPrefix(), l.installPrefix())
+		if err := l.Remote(ctx, mkdirCmd); err != nil {
+			return err
+		}
 	}
 	if err := l.UploadToDestination(ctx, l.serviceName); err != nil {
 		return err

--- a/exp/loom/loom_test.go
+++ b/exp/loom/loom_test.go
@@ -313,3 +313,56 @@ func TestLoom_Setup(t *testing.T) {
 		t.Error("Setup() expected error for nonexistent host, got nil")
 	}
 }
+
+func TestNewUser_SetsUserMode(t *testing.T) {
+	t.Setenv("LOOM_SSH_LOGIN", "kiosk")
+	t.Setenv("LOOM_SSH_HOSTNAME", "pi.local")
+	l, err := NewUser("hud", true)
+	if err != nil {
+		t.Fatalf("NewUser: %v", err)
+	}
+	if !l.userMode {
+		t.Error("NewUser should set userMode=true")
+	}
+	if l.serviceName != "hud" {
+		t.Errorf("serviceName = %q, want hud", l.serviceName)
+	}
+}
+
+func TestNew_DoesNotSetUserMode(t *testing.T) {
+	t.Setenv("LOOM_SSH_LOGIN", "root")
+	t.Setenv("LOOM_SSH_HOSTNAME", "host")
+	l, err := New("svc", false)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if l.userMode {
+		t.Error("New should leave userMode=false")
+	}
+}
+
+func TestPathHelpers_System(t *testing.T) {
+	l := &Loom{serviceName: "hud", userMode: false}
+	if got, want := l.systemdUnitDir(), "/etc/systemd/system"; got != want {
+		t.Errorf("systemdUnitDir() = %q, want %q", got, want)
+	}
+	if got, want := l.binPath(), "/opt/hud/bin/hud"; got != want {
+		t.Errorf("binPath() = %q, want %q", got, want)
+	}
+	if got, want := l.sudoPrefix(), "sudo "; got != want {
+		t.Errorf("sudoPrefix() = %q, want %q", got, want)
+	}
+}
+
+func TestPathHelpers_User(t *testing.T) {
+	l := &Loom{serviceName: "hud", userMode: true}
+	if got, want := l.systemdUnitDir(), "$HOME/.config/systemd/user"; got != want {
+		t.Errorf("systemdUnitDir() = %q, want %q", got, want)
+	}
+	if got, want := l.binPath(), "$HOME/.local/bin/hud"; got != want {
+		t.Errorf("binPath() = %q, want %q", got, want)
+	}
+	if l.sudoPrefix() != "" {
+		t.Errorf("sudoPrefix() should be empty in user mode, got %q", l.sudoPrefix())
+	}
+}

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -5,43 +5,75 @@ import (
 	"os"
 )
 
+// serviceTemplate emits a single systemd unit file. The User= line
+// is conditional so user units (which run as the invoking user by
+// definition) can omit it cleanly.
 var serviceTemplate = `[Unit]
 Description={{ .Name }}
 After={{ .After }}
 Requires={{ .Requires }}
 
 [Service]
+{{- if .User }}
 User={{ .User }}
+{{- end }}
 TimeoutStartSec={{ .TimeoutStartSec }}
 ExecStart={{ .ExecStart }}
 Restart={{ .Restart }}
 RestartSec={{ .RestartSec }}
 
 [Install]
-WantedBy=multi-user.target
+WantedBy={{ .WantedBy }}
 `
 
+// Service is the data model for a generated systemd unit. Two
+// presets:
+//
+//	NewService     -> system unit, runs as User (default "root"),
+//	                  WantedBy=multi-user.target.
+//	NewUserService -> user unit (lives under ~/.config/systemd/user/),
+//	                  no User= line, WantedBy=default.target.
+//
+// Operators can also build a Service by hand for cases that don't
+// fit either preset (e.g. a system unit running as a non-root user
+// like "kiosk" -- start from NewService and overwrite .User).
 type Service struct {
-	Name            string // name service
-	After           string //
-	Requires        string //
-	User            string // root
-	ExecStart       string // command
-	TimeoutStartSec int    // 0
-	Restart         string // always
-	RestartSec      int    // 3
+	Name            string
+	After           string
+	Requires        string
+	User            string // empty => omit User= line (user services)
+	ExecStart       string
+	TimeoutStartSec int
+	Restart         string
+	RestartSec      int
+	WantedBy        string // "multi-user.target" for system; "default.target" for user
 }
 
+// NewService returns a system-target unit running as root, with sane
+// restart defaults. Override fields to change User, After, etc.
 func NewService(name, execStart string) *Service {
 	return &Service{
 		Name:            name,
-		After:           "",
-		Requires:        "",
 		User:            "root",
 		ExecStart:       execStart,
 		TimeoutStartSec: 0,
 		Restart:         "always",
 		RestartSec:      3,
+		WantedBy:        "multi-user.target",
+	}
+}
+
+// NewUserService returns a user-target unit (no User= line, installed
+// under ~/.config/systemd/user/), with sane restart defaults.
+// Operators run/manage these via `systemctl --user`.
+func NewUserService(name, execStart string) *Service {
+	return &Service{
+		Name:            name,
+		ExecStart:       execStart,
+		TimeoutStartSec: 0,
+		Restart:         "always",
+		RestartSec:      3,
+		WantedBy:        "default.target",
 	}
 }
 
@@ -54,6 +86,6 @@ func (s *Service) ToFile(filename string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	return tmpl.Execute(f, s)
 }

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -266,6 +266,67 @@ func TestServiceToFilePermissions(t *testing.T) {
 	}
 }
 
+func TestNewUserService(t *testing.T) {
+	s := NewUserService("hud", "/home/kiosk/hud start")
+	if s.Name != "hud" {
+		t.Errorf("Name = %q, want hud", s.Name)
+	}
+	if s.User != "" {
+		t.Errorf("User = %q, want empty (user services run as the invoking user)", s.User)
+	}
+	if s.WantedBy != "default.target" {
+		t.Errorf("WantedBy = %q, want default.target", s.WantedBy)
+	}
+	if s.Restart != "always" || s.RestartSec != 3 {
+		t.Errorf("restart defaults wrong: %q / %d", s.Restart, s.RestartSec)
+	}
+}
+
+func TestUserServiceToFileOmitsUserLine(t *testing.T) {
+	s := NewUserService("hud", "/home/kiosk/hud start")
+	tmp, err := os.CreateTemp("", "user-*.service")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	defer os.Remove(tmp.Name())
+	tmp.Close()
+	if err := s.ToFile(tmp.Name()); err != nil {
+		t.Fatalf("ToFile: %v", err)
+	}
+	body, err := os.ReadFile(tmp.Name())
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	got := string(body)
+	if strings.Contains(got, "User=") {
+		t.Errorf("user-service unit should not emit a User= line; got:\n%s", got)
+	}
+	if !strings.Contains(got, "WantedBy=default.target") {
+		t.Errorf("user-service unit missing WantedBy=default.target; got:\n%s", got)
+	}
+	if !strings.Contains(got, "ExecStart=/home/kiosk/hud start") {
+		t.Errorf("user-service unit missing ExecStart; got:\n%s", got)
+	}
+}
+
+func TestServiceWantedByConfigurable(t *testing.T) {
+	s := NewService("svc", "/bin/svc")
+	s.WantedBy = "graphical.target"
+	tmp, err := os.CreateTemp("", "wantedby-*.service")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	defer os.Remove(tmp.Name())
+	tmp.Close()
+	if err := s.ToFile(tmp.Name()); err != nil {
+		t.Fatalf("ToFile: %v", err)
+	}
+	body, _ := os.ReadFile(tmp.Name())
+	if !strings.Contains(string(body), "WantedBy=graphical.target") {
+		t.Errorf("WantedBy override not honoured; got:\n%s", body)
+	}
+}
+
 func TestServiceToFileMultipleServices(t *testing.T) {
 	services := []*Service{
 		NewService("service1", "/bin/app1"),


### PR DESCRIPTION
## Summary

Adds first-class support for per-user systemd services across both packages. System-mode behaviour and API shape unchanged.

### `x/systemd`

- `Service` gains a configurable `WantedBy` field (default `multi-user.target`). Template emits it via `[Install]` instead of hardcoding.
- `Service.User` is now optional; the template emits the `User=` line only when non-empty so user-target units can omit it cleanly (user services run as the invoking user by definition).
- New constructor `NewUserService(name, execStart)` -> a unit with `WantedBy=default.target`, `User` unset, same restart defaults.

### `x/exp/loom`

- New constructor `NewUser(serviceName, useAgent)` -> `Loom` with the unexported `userMode` flag flipped. Existing `New(...)` behaviour byte-identical.
- Per-mode helpers (`systemdUnitDir`, `binPath`, `sudoPrefix`) drive every command path:

| Mode    | systemd unit dir              | binary path                 | sudo |
|---------|-------------------------------|----------------------------|------|
| system  | `/etc/systemd/system/`        | `/opt/<svc>/bin/<svc>`     | yes  |
| user    | `~/.config/systemd/user/`     | `~/.local/bin/<svc>`       | no   |

- `Service(ctx, cmd)` emits `systemctl --user <cmd> <svc>` in user mode; `sudo systemctl <cmd> <svc>` in system mode.
- `Setup` branches: user mode skips the `etc/` and `log/` mkdirs entirely. The daemon owns its config via XDG paths and logs to journald via systemd's stdout capture; only `~/.local/bin` and `~/.config/systemd/user` need to exist.

## Why `~/.local/bin` and not `~/.local/<svc>/{bin,etc,log}`

XDG already has good answers per role:

| Role         | XDG path                    |
|--------------|-----------------------------|
| Binary       | `~/.local/bin/<svc>`        |
| Config       | `~/.config/<svc>/`          |
| Logs         | journald                    |
| State        | `~/.local/state/<svc>/`     |

Forcing parity with the system-mode `/opt/<svc>/{bin,etc,log}` triple in user mode would create non-standard paths (`~/.local/etc/<svc>`, `~/.local/log/<svc>`) for no real benefit. The daemon's own XDG-aware config code + systemd's journal capture cover the same surface more correctly.

## Test plan

- [x] `go build ./...` clean.
- [x] `go test -race ./exp/loom/... ./systemd/...` green.
- [x] `golangci-lint run ./exp/loom/... ./systemd/...` 0 issues.
- [x] `NewUserService` produces a unit with no `User=` line and `WantedBy=default.target`.
- [x] `Service.WantedBy` override emits the right `[Install]`.
- [x] `NewUser` flips `userMode`; `New` does not.
- [x] Per-mode `systemdUnitDir` / `binPath` / `sudoPrefix` produce the expected strings.
- [ ] CI green.

## Downstream consumer

`heatxsink/hud` will pick up `x@<this tag>` and use `loom.NewUser(...)` + `systemd.NewUserService(...)` for its kiosk Pi deploy. Sketch:

```go
func Setup(ctx context.Context) error {
    mg.Deps(BuildPi)
    l, err := loom.NewUser(name, false)
    if err != nil { return err }
    ss := systemd.NewUserService(name, fmt.Sprintf("\/home/ngranado/.local/bin/%s start", name))
    fn := name + ".service"
    if err := ss.ToFile(fn); err != nil { return err }
    return l.Setup(ctx, fn)
}
```
EOF
)