### PR TITLE
fix(exp/http/handlers): preserve http.Flusher through responseRecorder

### DIFF
--- a/exp/http/handlers/handlers.go
+++ b/exp/http/handlers/handlers.go
@@ -145,6 +145,20 @@ func (r *responseRecorder) Write(b []byte) (int, error) {
 	return n, err
 }
 
+// Flush forwards to the wrapped writer if it implements http.Flusher,
+// so SSE handlers wrapped by AccessLog can still flush events to the
+// client. Without this method, a type assertion `w.(http.Flusher)` on
+// the recorder fails -- embedding the http.ResponseWriter interface
+// only promotes methods that exist on that interface, and Flush lives
+// on a separate http.Flusher interface. Silent no-op when the
+// underlying writer doesn't support flushing (HTTP/1.0, test
+// recorders), matching the standard library's behaviour.
+func (r *responseRecorder) Flush() {
+	if f, ok := r.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
 func clientIP(r *http.Request) string {
 	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
 		if ip, _, err := net.SplitHostPort(strings.TrimSpace(strings.Split(xff, ",")[0])); err == nil {

--- a/exp/http/handlers/handlers_test.go
+++ b/exp/http/handlers/handlers_test.go
@@ -587,3 +587,36 @@ func TestMiddlewareChaining(t *testing.T) {
 		t.Error("Expected minified HTML content")
 	}
 }
+
+// TestAccessLog_PreservesFlusher guards against a regression where the
+// responseRecorder wrapper hides http.Flusher from SSE handlers. Without
+// the explicit Flush() delegation on responseRecorder, the type
+// assertion w.(http.Flusher) inside an AccessLog-wrapped handler fails
+// and SSE responses 500 with "streaming unsupported".
+func TestAccessLog_PreservesFlusher(t *testing.T) {
+	logCore, _ := observer.New(zapcore.InfoLevel)
+	zl := zap.New(logCore)
+
+	flushed := false
+	handler := logger.WithLogger(zl)(AccessLog(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("AccessLog-wrapped writer must implement http.Flusher")
+			return
+		}
+		_, _ = w.Write([]byte("hello"))
+		f.Flush()
+		flushed = true
+	})))
+
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !flushed {
+		t.Fatal("handler never reached Flush call")
+	}
+	if rec.Body.String() != "hello" {
+		t.Errorf("body = %q, want %q", rec.Body.String(), "hello")
+	}
+}


### PR DESCRIPTION
## Summary

`AccessLog` wraps every request in a `responseRecorder` that embeds the `http.ResponseWriter` interface to capture status and byte count. Embedding an interface only promotes methods defined on that interface, and `Flush()` lives on the separate `http.Flusher` interface — so a type assertion `w.(http.Flusher)` inside an AccessLog-wrapped handler fails. SSE handlers downstream then 500 with \"streaming unsupported\".

Discovered in hud, where a new `/server/events` SSE endpoint returned that error after every request despite the path being bypassed for Compress and Minify (AccessLog has no bypass — it wraps every request, by design).

The fix is to add an explicit `Flush()` method on `responseRecorder` that delegates to the wrapped writer if it implements Flusher, no-op otherwise. Matches stdlib behaviour for HTTP/1.0 connections and test recorders.

## Test plan

- [x] `go test ./exp/http/handlers/` passes
- [x] New test `TestAccessLog_PreservesFlusher` asserts the type assertion succeeds and `Flush()` does not panic
- [ ] hud's `/server/events` and `/modules/{name}/events` SSE endpoints stream correctly after bumping x to the new release