### PR TITLE
fix(dependabot): drop duplicate (deps) from gomod commit prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
       - "dependencies"
       - "go"
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "chore"
       include: "scope"
     groups:
       otel:


### PR DESCRIPTION
## Summary
The previous config produced commit messages like `chore(deps)(deps): bump foo` because `prefix: "chore(deps)"` combined with `include: "scope"` (which auto-prepends `(deps)` for the gomod ecosystem). Switching the prefix to `"chore"` yields the conventional `chore(deps): bump foo`.

The github-actions block already produces correctly-formatted titles (`chore(actions): bump foo`) since it doesn't set `include: "scope"`.

## Test plan
- [x] Inspect rendered title in next Monday's dependabot run (cosmetic only — no behavior change)