### PR TITLE
chore(ci): drop gosec, keep govulncheck for security scanning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,45 +74,6 @@ jobs:
     - name: Run govulncheck
       run: govulncheck ./...
 
-    - name: Install Gosec
-      run: go install github.com/securego/gosec/v2/cmd/gosec@latest
-        
-    - name: Run Gosec Security Scanner (JSON output)
-      run: |
-        gosec -fmt json -out gosec-results.json ./...
-        echo "Gosec scan completed"
-      continue-on-error: true
-      
-    - name: Run Gosec Security Scanner (SARIF output)
-      run: |
-        gosec -fmt sarif -out gosec-results.sarif ./...
-        echo "SARIF output generated"
-      continue-on-error: true
-      
-    - name: Display Gosec Results
-      run: |
-        if [ -f gosec-results.json ]; then
-          echo "Security scan results:"
-          cat gosec-results.json | jq -r '.Issues[]? | "Issue: \(.rule_id) - \(.details) at \(.file):\(.line)"' || cat gosec-results.json
-        fi
-      continue-on-error: true
-      
-    - name: Upload SARIF file
-      uses: github/codeql-action/upload-sarif@v3
-      with:
-        sarif_file: gosec-results.sarif
-      if: always() && hashFiles('gosec-results.sarif') != ''
-      continue-on-error: true
-      
-    - name: Upload security scan artifacts
-      uses: actions/upload-artifact@v7
-      with:
-        name: security-scan-results
-        path: |
-          gosec-results.json
-          gosec-results.sarif
-      if: always()
-        
   build:
     name: Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Removes the gosec steps from the `security` job in `test.yml`. They were all `continue-on-error: true`, so they never blocked the build, and the SARIF/JSON outputs weren't being consumed by any Code Scanning workflow — pure noise. `govulncheck` remains as the actively-enforced security check (CVE scanning on dependencies, including weekly cron).

If we ever want SAST on our own code, we can add Code Scanning with CodeQL or re-introduce gosec with proper enforcement.

## Test plan
- [x] `security` job in CI runs only `govulncheck` and is enforced