### PR TITLE
fix(ci): pin Go to 1.26.4 to clear stdlib CVEs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch: # Allow manual trigger
 
 env:
-  GO_VERSION: '1.26.x'
+  GO_VERSION: '1.26.4'
 
 jobs:
   build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: '1.26.x'
+  GO_VERSION: '1.26.4'
 
 jobs:
   golangci-lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch: # Allow manual trigger
 
 env:
-  GO_VERSION: '1.26.x'
+  GO_VERSION: '1.26.4'
 
 jobs:
   test:
@@ -19,7 +19,7 @@ jobs:
     
     strategy:
       matrix:
-        go-version: ['1.26.x']
+        go-version: ['1.26.4']
     
     steps:
     - name: Checkout code

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/heatxsink/x
 
 go 1.25.0
 
-toolchain go1.26.2
+toolchain go1.26.4
 
 require (
 	cloud.google.com/go/secretmanager v1.20.0


### PR DESCRIPTION
## Summary

The Security Scan (`govulncheck`) on CI was failing because the `1.26.x` version spec resolved to the runner's pre-installed **go1.26.3**, which is affected by two standard-library vulnerabilities:

- **GO-2026-5039** — `net/textproto` arbitrary inputs in errors without escaping (reached via `exp/iot/wled/wled.go:209`)
- **GO-2026-5037** — `crypto/x509` inefficient hostname parsing (reached via `exp/storage/gcs.go:108`, `exp/iot/iot.go:27`)

Both are fixed in **go1.26.4**. This pins the toolchain explicitly so CI uses the patched stdlib instead of whatever patch release the runner happens to have cached.

## Changes

- `GO_VERSION: '1.26.x'` → `'1.26.4'` in `go.yml`, `lint.yml`, `test.yml`
- Test matrix `go-version` → `'1.26.4'`
- `go.mod` toolchain directive `go1.26.2` → `go1.26.4`

## Test plan

- [x] `go build ./...` passes on go1.26.4
- [x] `GOTOOLCHAIN=go1.26.4 govulncheck ./...` → **No vulnerabilities found** (was 2)
- [ ] CI green, Security Scan passes