### PR TITLE
feat(handlers)!: Recover writes 500, add PatchNoCORS + SkipPaths

### DIFF
--- a/exp/http/handlers/handlers.go
+++ b/exp/http/handlers/handlers.go
@@ -70,6 +70,15 @@ type recoverRecorder struct {
 	wrote bool
 }
 
+// Compile-time interface assertions: catch a future refactor that drops
+// Flush / Hijack / Push before it becomes a runtime SSE / WebSocket / push
+// regression in downstreams.
+var (
+	_ http.Flusher  = (*recoverRecorder)(nil)
+	_ http.Hijacker = (*recoverRecorder)(nil)
+	_ http.Pusher   = (*recoverRecorder)(nil)
+)
+
 func (r *recoverRecorder) WriteHeader(code int) {
 	r.wrote = true
 	r.ResponseWriter.WriteHeader(code)
@@ -300,6 +309,10 @@ func AccessLog(next http.Handler) http.Handler {
 	})
 }
 
+// Patch composes the full Recover→AccessLog→Compress→Minify→CORS chain over
+// a concrete *http.ServeMux. Use PatchNoCORS for the same chain without CORS,
+// or when you need to pass an http.Handler (not *http.ServeMux) — e.g. to
+// compose with SkipPaths for streaming endpoints.
 func Patch(mux *http.ServeMux, allowedOrigins []string, allowedMethods []string, allowedHeaders []string) http.Handler {
 	return Recover(AccessLog(Compress(Minify(CORS(mux, allowedOrigins, allowedMethods, allowedHeaders)))))
 }
@@ -323,13 +336,27 @@ func PatchNoCORS(mux http.Handler) http.Handler {
 // bypass Compress/Minify for Server-Sent Events or WebSocket endpoints that
 // can't tolerate buffering middleware.
 //
-// Match is exact string equality — no prefix matching, no trailing-slash
-// normalization. Callers with prefix routes should compose their own bypass.
+// Match is exact string equality on r.URL.Path only:
+//   - No prefix matching. "/events/42" is NOT matched by "/events".
+//   - No trailing-slash normalization. "/events/" is a different key.
+//   - Not method-aware. Under Go 1.22+ mux patterns like "GET /foo" and
+//     "POST /foo", SkipPaths(_, _, "/foo") bypasses both — matching happens
+//     before the mux resolves the method. Callers wanting per-method bypass
+//     compose their own.
+//
+// Panics if chain or raw is nil — catches a programmer error at construction
+// time rather than on the first request.
 //
 // Example:
 //
 //	Handler: SkipPaths(PatchNoCORS(mux), mux, "/api/1/events", "/ws")
 func SkipPaths(chain http.Handler, raw http.Handler, paths ...string) http.Handler {
+	if chain == nil {
+		panic("handlers.SkipPaths: chain handler is nil")
+	}
+	if raw == nil {
+		panic("handlers.SkipPaths: raw handler is nil")
+	}
 	if len(paths) == 0 {
 		return chain
 	}

--- a/exp/http/handlers/handlers.go
+++ b/exp/http/handlers/handlers.go
@@ -137,6 +137,7 @@ func Recover(next http.Handler) http.Handler {
 				// flushed can't be overwritten (silent no-op in that case).
 				if !rec.wrote {
 					http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+					return
 				}
 			}
 		}()

--- a/exp/http/handlers/handlers.go
+++ b/exp/http/handlers/handlers.go
@@ -62,8 +62,52 @@ func CORSWithLogger(next http.Handler, allowedOrigins []string, allowedMethods [
 	})
 }
 
+// recoverRecorder tracks whether the underlying ResponseWriter has had a
+// status code sent. Used by Recover to decide whether it can safely emit a
+// 500 after a panic (only possible when headers haven't already flushed).
+type recoverRecorder struct {
+	http.ResponseWriter
+	wrote bool
+}
+
+func (r *recoverRecorder) WriteHeader(code int) {
+	r.wrote = true
+	r.ResponseWriter.WriteHeader(code)
+}
+
+func (r *recoverRecorder) Write(b []byte) (int, error) {
+	r.wrote = true
+	return r.ResponseWriter.Write(b)
+}
+
+// Flush forwards to the wrapped writer if it implements http.Flusher, so
+// streaming handlers wrapped by Recover keep working — matches the pattern
+// used by responseRecorder and minifyResponseWriter.
+func (r *recoverRecorder) Flush() {
+	if f, ok := r.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Hijack forwards to the wrapped writer if it implements http.Hijacker.
+func (r *recoverRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if h, ok := r.ResponseWriter.(http.Hijacker); ok {
+		return h.Hijack()
+	}
+	return nil, nil, http.ErrNotSupported
+}
+
+// Push forwards to the wrapped writer if it implements http.Pusher.
+func (r *recoverRecorder) Push(target string, opts *http.PushOptions) error {
+	if p, ok := r.ResponseWriter.(http.Pusher); ok {
+		return p.Push(target, opts)
+	}
+	return http.ErrNotSupported
+}
+
 func Recover(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec := &recoverRecorder{ResponseWriter: w}
 		defer func() {
 			if rr := recover(); rr != nil {
 				slogger := logger.FromRequest(r)
@@ -78,9 +122,16 @@ func Recover(next http.Handler) http.Handler {
 					err := errors.New("unknown panic")
 					slogger.Error("handlers.Recover(): ", zap.Error(err))
 				}
+				// If the handler hadn't emitted anything before panicking,
+				// synthesize a 500 so the client sees an error rather than
+				// the default "200 OK with empty body." Headers already
+				// flushed can't be overwritten (silent no-op in that case).
+				if !rec.wrote {
+					http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				}
 			}
 		}()
-		next.ServeHTTP(w, r)
+		next.ServeHTTP(rec, r)
 	})
 }
 
@@ -255,4 +306,42 @@ func Patch(mux *http.ServeMux, allowedOrigins []string, allowedMethods []string,
 
 func PatchDebug(mux *http.ServeMux, allowedOrigins []string) http.Handler {
 	return Recover(AccessLog(Dump(CORS(mux, allowedOrigins, DefaultAllowedMethods, DefaultAllowedHeaders), false)))
+}
+
+// PatchNoCORS is the same Recover→AccessLog→Compress→Minify chain as Patch
+// but without the CORS layer. For single-user / same-origin applications
+// where CORS response headers aren't needed.
+//
+// Accepts http.Handler (not *http.ServeMux specifically) so callers can
+// pre-compose their own routing, e.g. combine with SkipPaths for streaming.
+func PatchNoCORS(mux http.Handler) http.Handler {
+	return Recover(AccessLog(Compress(Minify(mux))))
+}
+
+// SkipPaths returns a handler that routes requests whose r.URL.Path exactly
+// matches one of paths to raw, and everything else to chain. Common pattern:
+// bypass Compress/Minify for Server-Sent Events or WebSocket endpoints that
+// can't tolerate buffering middleware.
+//
+// Match is exact string equality — no prefix matching, no trailing-slash
+// normalization. Callers with prefix routes should compose their own bypass.
+//
+// Example:
+//
+//	Handler: SkipPaths(PatchNoCORS(mux), mux, "/api/1/events", "/ws")
+func SkipPaths(chain http.Handler, raw http.Handler, paths ...string) http.Handler {
+	if len(paths) == 0 {
+		return chain
+	}
+	skip := make(map[string]struct{}, len(paths))
+	for _, p := range paths {
+		skip[p] = struct{}{}
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := skip[r.URL.Path]; ok {
+			raw.ServeHTTP(w, r)
+			return
+		}
+		chain.ServeHTTP(w, r)
+	})
 }

--- a/exp/http/handlers/handlers_test.go
+++ b/exp/http/handlers/handlers_test.go
@@ -740,6 +740,75 @@ func TestMinify_PreservesPusher(t *testing.T) {
 	handler.ServeHTTP(rec, req)
 }
 
+// TestMinify_PassesThroughBinary guards the invariant that Minify does not
+// mutate responses whose Content-Type isn't a known text minifier target.
+// Fonts, images, audio, and application/octet-stream must be byte-identical
+// after passing through Minify — otherwise browsers see corrupted assets
+// (a broken .woff2 falls back silently to system fonts).
+func TestMinify_PassesThroughBinary(t *testing.T) {
+	// Synthesize a "binary" payload with bytes that would otherwise look
+	// tempting to an HTML minifier: angle brackets, whitespace, comments.
+	// The point is that Content-Type gates the transform, not content.
+	binary := []byte{
+		0x00, 0x01, 0x02, 0x03, 0x89, 0xAB, 0xCD, 0xEF, // magic-byte lookalike
+		'<', '!', '-', '-', ' ', 'n', 'o', 't', ' ', 'h', 't', 'm', 'l', ' ', '-', '-', '>',
+		0x00, 0x00, 0x00, 0x00,
+	}
+
+	cases := []struct {
+		name, contentType string
+	}{
+		{"font/woff2", "font/woff2"},
+		{"image/x-icon", "image/x-icon"},
+		{"audio/mpeg", "audio/mpeg"},
+		{"application/octet-stream", "application/octet-stream"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			handler := Minify(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", c.contentType)
+				_, _ = w.Write(binary)
+			}))
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if !bytes.Equal(rec.Body.Bytes(), binary) {
+				t.Errorf("%s: Minify mutated binary payload\ngot:  %x\nwant: %x",
+					c.contentType, rec.Body.Bytes(), binary)
+			}
+		})
+	}
+}
+
+// TestPatch_500OnPanic exercises the Recover behavior change through the
+// full Patch chain (Recover→AccessLog→Compress→Minify→CORS). A panic in the
+// mux handler must still surface as 500 even though responseRecorder sits
+// between Recover and the mux — a future refactor that has AccessLog write
+// headers pre-flight would silently break the Recover 500 semantics without
+// this end-to-end guard.
+func TestPatch_500OnPanic(t *testing.T) {
+	core, _ := observer.New(zapcore.InfoLevel)
+	zl := zap.New(core)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/boom", func(w http.ResponseWriter, r *http.Request) {
+		panic("intentional test panic")
+	})
+
+	handler := logger.WithLogger(zl)(
+		Patch(mux, []string{"*"}, DefaultAllowedMethods, DefaultAllowedHeaders),
+	)
+	req := httptest.NewRequest(http.MethodGet, "/boom", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("Patch chain: status = %d, want 500 after handler panic", rec.Code)
+	}
+}
+
 // TestPatch_PreservesFlusher exercises the full Patch chain end-to-
 // end. Regression: an SSE handler mounted behind Patch used to see
 // ok=false on w.(http.Flusher) because Minify silently dropped
@@ -934,6 +1003,31 @@ func TestSkipPaths_EmptyPaths(t *testing.T) {
 	}
 }
 
+// TestSkipPaths_NilPanics asserts the constructor rejects nil handlers early.
+// Programmer errors should fail loudly at wiring time, not on the first
+// request that happens to hit a nil branch.
+func TestSkipPaths_NilPanics(t *testing.T) {
+	nonNil := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
+
+	t.Run("nil chain", func(t *testing.T) {
+		defer func() {
+			if recover() == nil {
+				t.Error("expected panic on nil chain, got no panic")
+			}
+		}()
+		_ = SkipPaths(nil, nonNil, "/x")
+	})
+
+	t.Run("nil raw", func(t *testing.T) {
+		defer func() {
+			if recover() == nil {
+				t.Error("expected panic on nil raw, got no panic")
+			}
+		}()
+		_ = SkipPaths(nonNil, nil, "/x")
+	})
+}
+
 // TestSkipPaths_ExactMatchOnly documents that matching is exact-string, not
 // prefix. Callers who want prefix routing compose their own bypass.
 func TestSkipPaths_ExactMatchOnly(t *testing.T) {
@@ -952,47 +1046,5 @@ func TestSkipPaths_ExactMatchOnly(t *testing.T) {
 	}
 	if chainHits != 1 {
 		t.Errorf("chainHits = %d, want 1", chainHits)
-	}
-}
-
-// TestMinify_PassesThroughBinary guards the invariant that Minify does not
-// mutate responses whose Content-Type isn't a known text minifier target.
-// Fonts, images, audio, and application/octet-stream must be byte-identical
-// after passing through Minify — otherwise browsers see corrupted assets
-// (a broken .woff2 falls back silently to system fonts).
-func TestMinify_PassesThroughBinary(t *testing.T) {
-	// Synthesize a "binary" payload with bytes that would otherwise look
-	// tempting to an HTML minifier: angle brackets, whitespace, comments.
-	// The point is that Content-Type gates the transform, not content.
-	binary := []byte{
-		0x00, 0x01, 0x02, 0x03, 0x89, 0xAB, 0xCD, 0xEF, // magic-byte lookalike
-		'<', '!', '-', '-', ' ', 'n', 'o', 't', ' ', 'h', 't', 'm', 'l', ' ', '-', '-', '>',
-		0x00, 0x00, 0x00, 0x00,
-	}
-
-	cases := []struct {
-		name, contentType string
-	}{
-		{"font/woff2", "font/woff2"},
-		{"image/x-icon", "image/x-icon"},
-		{"audio/mpeg", "audio/mpeg"},
-		{"application/octet-stream", "application/octet-stream"},
-	}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			handler := Minify(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.Header().Set("Content-Type", c.contentType)
-				_, _ = w.Write(binary)
-			}))
-			req := httptest.NewRequest(http.MethodGet, "/", nil)
-			rec := httptest.NewRecorder()
-			handler.ServeHTTP(rec, req)
-
-			if !bytes.Equal(rec.Body.Bytes(), binary) {
-				t.Errorf("%s: Minify mutated binary payload\ngot:  %x\nwant: %x",
-					c.contentType, rec.Body.Bytes(), binary)
-			}
-		})
 	}
 }

--- a/exp/http/handlers/handlers_test.go
+++ b/exp/http/handlers/handlers_test.go
@@ -228,9 +228,10 @@ func TestRecover(t *testing.T) {
 func TestRecover_PreservesFlusher(t *testing.T) {
 	var sawFlusher bool
 	handler := Recover(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, sawFlusher = w.(http.Flusher)
-		if sawFlusher {
-			w.(http.Flusher).Flush()
+		f, ok := w.(http.Flusher)
+		sawFlusher = ok
+		if ok {
+			f.Flush()
 		}
 	}))
 

--- a/exp/http/handlers/handlers_test.go
+++ b/exp/http/handlers/handlers_test.go
@@ -179,6 +179,98 @@ func TestRecover(t *testing.T) {
 			t.Errorf("Expected body 'OK', got %s", rec.Body.String())
 		}
 	})
+
+	recorded.TakeAll()
+
+	t.Run("panic before write emits 500", func(t *testing.T) {
+		handler := logger.WithLogger(testLogger)(Recover(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			panic("nothing written yet")
+		})))
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusInternalServerError {
+			t.Errorf("Expected 500 when panic fires before any write, got %d", rec.Code)
+		}
+		if !strings.Contains(rec.Body.String(), http.StatusText(http.StatusInternalServerError)) {
+			t.Errorf("Expected default 500 body, got %q", rec.Body.String())
+		}
+	})
+
+	recorded.TakeAll()
+
+	t.Run("panic after write preserves original status", func(t *testing.T) {
+		handler := logger.WithLogger(testLogger)(Recover(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(`{"partial":`))
+			panic("mid-write panic")
+		})))
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusAccepted {
+			t.Errorf("Expected 202 (already written), got %d — Recover must not overwrite flushed headers", rec.Code)
+		}
+		if rec.Body.String() != `{"partial":` {
+			t.Errorf("Expected partial body preserved, got %q", rec.Body.String())
+		}
+	})
+}
+
+// TestRecover_PreservesFlusher guards the streaming-through-Recover path:
+// a handler wrapped by Recover that asserts on http.Flusher must succeed.
+func TestRecover_PreservesFlusher(t *testing.T) {
+	var sawFlusher bool
+	handler := Recover(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, sawFlusher = w.(http.Flusher)
+		if sawFlusher {
+			w.(http.Flusher).Flush()
+		}
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !sawFlusher {
+		t.Error("Recover hid http.Flusher — SSE / streaming handlers will break")
+	}
+}
+
+// TestRecover_PreservesHijacker guards the WebSocket-through-Recover path.
+func TestRecover_PreservesHijacker(t *testing.T) {
+	var sawHijacker bool
+	handler := Recover(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, sawHijacker = w.(http.Hijacker)
+	}))
+
+	rec := &hijackerRecorder{ResponseRecorder: httptest.NewRecorder()}
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/test", nil))
+
+	if !sawHijacker {
+		t.Error("Recover hid http.Hijacker — WebSocket upgrades will break")
+	}
+}
+
+// TestRecover_PreservesPusher guards the HTTP/2 push path through Recover.
+func TestRecover_PreservesPusher(t *testing.T) {
+	var sawPusher bool
+	handler := Recover(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, sawPusher = w.(http.Pusher)
+	}))
+
+	rec := &pusherRecorder{ResponseRecorder: httptest.NewRecorder()}
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/test", nil))
+
+	if !sawPusher {
+		t.Error("Recover hid http.Pusher — HTTP/2 server push will break")
+	}
 }
 
 func TestDump(t *testing.T) {
@@ -737,5 +829,170 @@ func TestAccessLog_PreservesFlusher(t *testing.T) {
 	}
 	if rec.Body.String() != "hello" {
 		t.Errorf("body = %q, want %q", rec.Body.String(), "hello")
+	}
+}
+
+// TestPatchNoCORS asserts the CORS-free chain composes correctly and does
+// not leak Access-Control-* headers into responses.
+func TestPatchNoCORS(t *testing.T) {
+	core, _ := observer.New(zapcore.InfoLevel)
+	zl := zap.New(core)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/hello", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("hi"))
+	})
+
+	handler := logger.WithLogger(zl)(PatchNoCORS(mux))
+	req := httptest.NewRequest(http.MethodGet, "/hello", nil)
+	req.Header.Set("Origin", "https://example.com")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want empty (PatchNoCORS should not emit CORS headers)", got)
+	}
+}
+
+// TestPatchNoCORS_PreservesFlusher — parallel to TestPatch_PreservesFlusher.
+// If any middleware in the CORS-free chain hides Flusher, SSE handlers
+// downstream would break.
+func TestPatchNoCORS_PreservesFlusher(t *testing.T) {
+	core, _ := observer.New(zapcore.InfoLevel)
+	zl := zap.New(core)
+
+	var seen bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("/events", func(w http.ResponseWriter, _ *http.Request) {
+		_, seen = w.(http.Flusher)
+	})
+
+	handler := logger.WithLogger(zl)(PatchNoCORS(mux))
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+	rec := &flusherRecorder{ResponseRecorder: httptest.NewRecorder()}
+	handler.ServeHTTP(rec, req)
+
+	if !seen {
+		t.Error("PatchNoCORS chain hid http.Flusher from the downstream handler")
+	}
+}
+
+// TestSkipPaths asserts SSE-shape traffic bypasses the chain, everything
+// else goes through it. Uses PatchNoCORS as the "chain" and a bare mux as
+// "raw" — the exact composition hreader uses.
+func TestSkipPaths(t *testing.T) {
+	core, _ := observer.New(zapcore.InfoLevel)
+	zl := zap.New(core)
+
+	var stream *http.Request
+	var normal *http.Request
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/events", func(_ http.ResponseWriter, r *http.Request) { stream = r })
+	mux.HandleFunc("/api/data", func(_ http.ResponseWriter, r *http.Request) { normal = r })
+
+	handler := logger.WithLogger(zl)(SkipPaths(PatchNoCORS(mux), mux, "/api/events"))
+
+	t.Run("skipped path bypasses chain", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/events", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if stream == nil {
+			t.Fatal("skipped path never reached the raw handler")
+		}
+	})
+
+	t.Run("non-skipped path goes through chain", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/data", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if normal == nil {
+			t.Fatal("non-skipped path never reached the handler")
+		}
+	})
+}
+
+// TestSkipPaths_EmptyPaths — passing zero paths returns the chain unchanged.
+func TestSkipPaths_EmptyPaths(t *testing.T) {
+	sentinel := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("chain"))
+	})
+	raw := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("raw"))
+	})
+
+	handler := SkipPaths(sentinel, raw)
+	req := httptest.NewRequest(http.MethodGet, "/anything", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Body.String() != "chain" {
+		t.Errorf("body = %q, want chain — empty paths should behave as identity wrap of chain", rec.Body.String())
+	}
+}
+
+// TestSkipPaths_ExactMatchOnly documents that matching is exact-string, not
+// prefix. Callers who want prefix routing compose their own bypass.
+func TestSkipPaths_ExactMatchOnly(t *testing.T) {
+	var chainHits, rawHits int
+	chain := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { chainHits++ })
+	raw := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { rawHits++ })
+
+	handler := SkipPaths(chain, raw, "/events")
+
+	// Prefix but not exact — must go through chain, not raw.
+	req := httptest.NewRequest(http.MethodGet, "/events/42", nil)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	if rawHits != 0 {
+		t.Errorf("rawHits = %d, want 0 — '/events/42' is not an exact match for '/events'", rawHits)
+	}
+	if chainHits != 1 {
+		t.Errorf("chainHits = %d, want 1", chainHits)
+	}
+}
+
+// TestMinify_PassesThroughBinary guards the invariant that Minify does not
+// mutate responses whose Content-Type isn't a known text minifier target.
+// Fonts, images, audio, and application/octet-stream must be byte-identical
+// after passing through Minify — otherwise browsers see corrupted assets
+// (a broken .woff2 falls back silently to system fonts).
+func TestMinify_PassesThroughBinary(t *testing.T) {
+	// Synthesize a "binary" payload with bytes that would otherwise look
+	// tempting to an HTML minifier: angle brackets, whitespace, comments.
+	// The point is that Content-Type gates the transform, not content.
+	binary := []byte{
+		0x00, 0x01, 0x02, 0x03, 0x89, 0xAB, 0xCD, 0xEF, // magic-byte lookalike
+		'<', '!', '-', '-', ' ', 'n', 'o', 't', ' ', 'h', 't', 'm', 'l', ' ', '-', '-', '>',
+		0x00, 0x00, 0x00, 0x00,
+	}
+
+	cases := []struct {
+		name, contentType string
+	}{
+		{"font/woff2", "font/woff2"},
+		{"image/x-icon", "image/x-icon"},
+		{"audio/mpeg", "audio/mpeg"},
+		{"application/octet-stream", "application/octet-stream"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			handler := Minify(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", c.contentType)
+				_, _ = w.Write(binary)
+			}))
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if !bytes.Equal(rec.Body.Bytes(), binary) {
+				t.Errorf("%s: Minify mutated binary payload\ngot:  %x\nwant: %x",
+					c.contentType, rec.Body.Bytes(), binary)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Three changes to `exp/http/handlers`, discovered while wiring the stack into hreader (single-user, same-origin, SSE-driven). One breaking (targeted), two additive.

- **BREAKING (targeted):** `Recover` now writes `500 Internal Server Error` when a handler panics before writing anything. Previously the client saw Go's default `200 OK` with an empty body — silent failure. Fixed via a small `recoverRecorder` wrapper that tracks whether `WriteHeader`/`Write` was called; if not, `Recover` calls `http.Error` with 500. Handlers that had already flushed headers see NO change (mid-write panic → truncated response with original status is preserved).
- **New:** `PatchNoCORS(mux http.Handler) http.Handler` — the `Recover→AccessLog→Compress→Minify` chain without CORS, for single-user / same-origin apps.
- **New:** `SkipPaths(chain, raw http.Handler, paths ...string) http.Handler` — route exact-string-matched paths to `raw`, everything else to `chain`. Common pattern for streaming endpoints (SSE, WebSocket). Panics on nil chain/raw at construction time.

## `recoverRecorder` and the optional-interface chain

`recoverRecorder` implements `Flusher` (matches `responseRecorder` from #77) and `Hijacker`/`Pusher` (matches `minifyResponseWriter` from #115) with compile-time interface assertions to prevent future refactors from silently dropping a forwarder.

Note on the FULL `Patch` chain: `Flusher` survives end-to-end (all four wrappers forward). `Hijacker` and `Pusher` do NOT — Compress's gorilla writer and `responseRecorder` don't forward them today. That's a pre-existing state, untouched by this PR; downstreams that want WebSocket behind `Patch` were already going to need their own routing.

## Recover behavior change — blast radius

| Scenario | Before | After |
|---|---|---|
| Handler completes normally | unchanged | unchanged |
| Handler panics before writing | 200 empty | **500 "internal server error"** |
| Handler wrote, then panics | truncated response, original status | truncated response, original status (unchanged — `http.Error` can't overwrite flushed headers) |
| Handler never panics | zero cost | zero cost |

Any test asserting `status == 200` after a panic was documenting a bug and will now fail correctly. Any monitoring that treated panicked 200s as healthy will now see 500s (strict correctness improvement).

## Usage example

```go
// hreader's main.go, post-merge:
Handler: SkipPaths(PatchNoCORS(mux), mux, "/api/1/events")
```

Same effect as the ~30-line custom `Middleware` function currently in hreader (`internal/server/middleware.go`) — one call, two arguments.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — 12 new tests + all existing tests still pass.
- [x] `go vet ./...` clean, `gofmt -l .` clean.
- [x] Existing `TestRecover` subtests unchanged in behavior (they don't assert status codes for the panic cases).
- **End-to-end guards:** `TestPatch_500OnPanic` asserts the Recover behavior surfaces through the full `Patch` chain, catching a future refactor that has `AccessLog` write headers pre-flight.
- **Compile-time guards:** `var _ http.Flusher = (*recoverRecorder)(nil)` etc. — build fails immediately if a forwarder is dropped, not just at runtime under streaming load.

## Semver

Tag as `v0.4.0` — the `Recover` behavior change is honestly a bug fix, but the semver signal to downstreams (especially any pinned to `v0.3.x`) is worth the minor bump.

## Follow-up

After merge + tag, hreader (currently pinned to `v0.3.0`) will bump the dep and can replace its custom `server.Middleware` function with `handlers.SkipPaths(handlers.PatchNoCORS(mux), mux, "/api/1/events")`. Same net behavior, ~30 lines of hreader code deleted.