### PR TITLE
ci: bump Go version to 1.26.5

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch: # Allow manual trigger
 
 env:
-  GO_VERSION: '1.26.4'
+  GO_VERSION: '1.26.5'
 
 jobs:
   build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: '1.26.4'
+  GO_VERSION: '1.26.5'
 
 jobs:
   golangci-lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch: # Allow manual trigger
 
 env:
-  GO_VERSION: '1.26.4'
+  GO_VERSION: '1.26.5'
 
 jobs:
   test:
@@ -19,7 +19,7 @@ jobs:
     
     strategy:
       matrix:
-        go-version: ['1.26.4']
+        go-version: ['1.26.5']
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
## Summary
- Bumps `GO_VERSION` from `1.26.4` to `1.26.5` across all three workflows (`go.yml`, `lint.yml`, `test.yml`) and the test matrix.
- Picks up the stdlib `crypto/tls` fix for [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856) (Encrypted Client Hello privacy leak), which `govulncheck` currently flags on every PR and on `main`.

## Test plan
- [ ] Build / Lint / Tests all pass on Go 1.26.5
- [ ] Security Scan (`govulncheck`) no longer reports GO-2026-5856