### PR TITLE
feat(exp/storage): conditional writes via generation preconditions

### DIFF
--- a/exp/storage/conditional_test.go
+++ b/exp/storage/conditional_test.go
@@ -1,0 +1,292 @@
+package storage
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"google.golang.org/api/googleapi"
+)
+
+// condBackend pairs a ConditionalStore with a URI factory so the same
+// conditional-write contract can be asserted against every built-in backend.
+type condBackend struct {
+	name  string
+	store ConditionalStore
+	uri   func(key string) string
+}
+
+func condBackends(t *testing.T) []condBackend {
+	t.Helper()
+	dir := t.TempDir()
+	return []condBackend{
+		{
+			name:  "gcs",
+			store: newFakeGCSStore(t, "cond-bucket"),
+			uri:   func(key string) string { return "gs://cond-bucket/" + key },
+		},
+		{
+			name:  "file",
+			store: &fileStore{},
+			uri:   func(key string) string { return "file://" + filepath.ToSlash(filepath.Join(dir, key)) },
+		},
+		{
+			name:  "mem",
+			store: newMemStore(),
+			uri:   func(key string) string { return "mem://" + t.Name() + "/" + key },
+		},
+	}
+}
+
+func TestConditionalLifecycle(t *testing.T) {
+	ctx := context.Background()
+	for _, b := range condBackends(t) {
+		t.Run(b.name, func(t *testing.T) {
+			uri := b.uri("lifecycle.json")
+
+			// Missing object wraps ErrNotExist, same as Get.
+			if _, _, err := b.store.GetWithGeneration(ctx, uri); !errors.Is(err, ErrNotExist) {
+				t.Fatalf("GetWithGeneration missing: err = %v, want ErrNotExist", err)
+			}
+
+			// ifGeneration 0 creates when the object does not exist yet.
+			if err := b.store.PutBytesIfGeneration(ctx, uri, []byte(`{"v":1}`), "application/json", 0); err != nil {
+				t.Fatalf("PutBytesIfGeneration create: %v", err)
+			}
+			// ...and conflicts once it does.
+			if err := b.store.PutBytesIfGeneration(ctx, uri, []byte(`clobber`), "application/json", 0); !errors.Is(err, ErrPreconditionFailed) {
+				t.Fatalf("create-over-existing: err = %v, want ErrPreconditionFailed", err)
+			}
+
+			data, gen, err := b.store.GetWithGeneration(ctx, uri)
+			if err != nil {
+				t.Fatalf("GetWithGeneration: %v", err)
+			}
+			if string(data) != `{"v":1}` || gen == 0 {
+				t.Fatalf("GetWithGeneration = (%q, %d), want created content with a non-zero generation", data, gen)
+			}
+
+			// A write with the matching generation succeeds and changes it.
+			if err := b.store.PutBytesIfGeneration(ctx, uri, []byte(`{"v":2}`), "application/json", gen); err != nil {
+				t.Fatalf("PutBytesIfGeneration matched: %v", err)
+			}
+			data, gen2, err := b.store.GetWithGeneration(ctx, uri)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(data) != `{"v":2}` {
+				t.Fatalf("content after matched write = %q, want %q", data, `{"v":2}`)
+			}
+			if gen2 == gen {
+				t.Fatal("generation did not change after a successful conditional write")
+			}
+
+			// The stale generation now conflicts and must not clobber.
+			if err := b.store.PutBytesIfGeneration(ctx, uri, []byte(`clobber`), "application/json", gen); !errors.Is(err, ErrPreconditionFailed) {
+				t.Fatalf("stale-generation write: err = %v, want ErrPreconditionFailed", err)
+			}
+			data, gen3, err := b.store.GetWithGeneration(ctx, uri)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(data) != `{"v":2}` || gen3 != gen2 {
+				t.Fatalf("after rejected write: (%q, %d), want untouched (%q, %d)", data, gen3, `{"v":2}`, gen2)
+			}
+		})
+	}
+}
+
+func TestConditionalUnconditionalPutInvalidates(t *testing.T) {
+	ctx := context.Background()
+	for _, b := range condBackends(t) {
+		t.Run(b.name, func(t *testing.T) {
+			uri := b.uri("invalidate.txt")
+			if err := b.store.PutBytesIfGeneration(ctx, uri, []byte("first"), "text/plain", 0); err != nil {
+				t.Fatalf("create: %v", err)
+			}
+			_, gen, err := b.store.GetWithGeneration(ctx, uri)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// An unconditional write must bump the generation so the
+			// outstanding conditional writer loses.
+			if err := b.store.PutBytes(ctx, uri, []byte("unconditional"), "text/plain"); err != nil {
+				t.Fatalf("PutBytes: %v", err)
+			}
+			if err := b.store.PutBytesIfGeneration(ctx, uri, []byte("stale"), "text/plain", gen); !errors.Is(err, ErrPreconditionFailed) {
+				t.Fatalf("conditional write after PutBytes: err = %v, want ErrPreconditionFailed", err)
+			}
+			got, err := b.store.Get(ctx, uri)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(got, []byte("unconditional")) {
+				t.Fatalf("content = %q, want %q", got, "unconditional")
+			}
+		})
+	}
+}
+
+func TestConditionalRetryLoop(t *testing.T) {
+	ctx := context.Background()
+	for _, b := range condBackends(t) {
+		t.Run(b.name, func(t *testing.T) {
+			uri := b.uri("retry.txt")
+			if err := b.store.PutBytesIfGeneration(ctx, uri, []byte("base"), "text/plain", 0); err != nil {
+				t.Fatalf("create: %v", err)
+			}
+
+			// Classic read-modify-write loop with one simulated conflict: a
+			// rival writer sneaks in after the first read.
+			conflicted := false
+			for attempt := 0; ; attempt++ {
+				if attempt > 2 {
+					t.Fatal("retry loop did not converge")
+				}
+				data, gen, err := b.store.GetWithGeneration(ctx, uri)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !conflicted {
+					conflicted = true
+					if err := b.store.PutBytesIfGeneration(ctx, uri, []byte(string(data)+" rival"), "text/plain", gen); err != nil {
+						t.Fatalf("rival write: %v", err)
+					}
+				}
+				err = b.store.PutBytesIfGeneration(ctx, uri, []byte(string(data)+" mine"), "text/plain", gen)
+				if errors.Is(err, ErrPreconditionFailed) {
+					continue
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				break
+			}
+
+			got, err := b.store.Get(ctx, uri)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != "base rival mine" {
+				t.Fatalf("content = %q, want %q (retry must rebase on the rival's write)", got, "base rival mine")
+			}
+		})
+	}
+}
+
+func TestConditionalListGenerationConsistent(t *testing.T) {
+	ctx := context.Background()
+	for _, b := range condBackends(t) {
+		t.Run(b.name, func(t *testing.T) {
+			uri := b.uri("listgen/obj.txt")
+			if err := b.store.PutBytesIfGeneration(ctx, uri, []byte("x"), "text/plain", 0); err != nil {
+				t.Fatalf("create: %v", err)
+			}
+			_, gen, err := b.store.GetWithGeneration(ctx, uri)
+			if err != nil {
+				t.Fatal(err)
+			}
+			objs, err := b.store.List(ctx, b.uri("listgen/"))
+			if err != nil {
+				t.Fatalf("List: %v", err)
+			}
+			if len(objs) != 1 {
+				t.Fatalf("List len = %d, want 1: %+v", len(objs), objs)
+			}
+			if objs[0].Generation != gen {
+				t.Fatalf("List Generation = %d, want %d (must match GetWithGeneration)", objs[0].Generation, gen)
+			}
+		})
+	}
+}
+
+// TestFileStorePreexistingObjectGeneration pins the seeding rule: a file
+// written outside the store (no sidecar) reports generation 1, so a stale
+// gen-0 create cannot clobber it but a matched write can replace it.
+func TestFileStorePreexistingObjectGeneration(t *testing.T) {
+	fs := &fileStore{}
+	ctx := context.Background()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "legacy.txt"), []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	uri := "file://" + filepath.ToSlash(filepath.Join(dir, "legacy.txt"))
+
+	data, gen, err := fs.GetWithGeneration(ctx, uri)
+	if err != nil {
+		t.Fatalf("GetWithGeneration: %v", err)
+	}
+	if string(data) != "old" || gen != 1 {
+		t.Fatalf("GetWithGeneration = (%q, %d), want (%q, 1)", data, gen, "old")
+	}
+	if err := fs.PutBytesIfGeneration(ctx, uri, []byte("clobber"), "", 0); !errors.Is(err, ErrPreconditionFailed) {
+		t.Fatalf("gen-0 create over pre-existing file: err = %v, want ErrPreconditionFailed", err)
+	}
+	if err := fs.PutBytesIfGeneration(ctx, uri, []byte("new"), "", gen); err != nil {
+		t.Fatalf("matched write over pre-existing file: %v", err)
+	}
+	_, gen2, err := fs.GetWithGeneration(ctx, uri)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gen2 != gen+1 {
+		t.Fatalf("generation after write = %d, want %d", gen2, gen+1)
+	}
+}
+
+// TestGCSPreconditionMapping pins the 412 -> ErrPreconditionFailed
+// translation independent of the fake server's behavior.
+func TestGCSPreconditionMapping(t *testing.T) {
+	if !isPreconditionFailed(&googleapi.Error{Code: http.StatusPreconditionFailed}) {
+		t.Error("412 googleapi error not recognized as a precondition failure")
+	}
+	if isPreconditionFailed(&googleapi.Error{Code: http.StatusTooManyRequests}) {
+		t.Error("429 misclassified as a precondition failure")
+	}
+	if isPreconditionFailed(errors.New("plain")) {
+		t.Error("non-API error misclassified as a precondition failure")
+	}
+}
+
+func TestPackageConditionalHelpers(t *testing.T) {
+	ctx := context.Background()
+	uri := "mem://" + t.Name() + "/helper.txt"
+
+	if err := PutBytesIfGeneration(ctx, uri, []byte("v1"), "text/plain", 0); err != nil {
+		t.Fatalf("PutBytesIfGeneration: %v", err)
+	}
+	data, gen, err := GetWithGeneration(ctx, uri)
+	if err != nil {
+		t.Fatalf("GetWithGeneration: %v", err)
+	}
+	if string(data) != "v1" || gen == 0 {
+		t.Fatalf("GetWithGeneration = (%q, %d), want (%q, non-zero)", data, gen, "v1")
+	}
+	if err := PutBytesIfGeneration(ctx, uri, []byte("v2"), "text/plain", gen); err != nil {
+		t.Fatalf("PutBytesIfGeneration matched: %v", err)
+	}
+}
+
+// plainStore implements Store but not ConditionalStore, standing in for an
+// external backend without conditional support.
+type plainStore struct{ Store }
+
+func TestPackageConditionalHelpersUnsupported(t *testing.T) {
+	t.Cleanup(resetForTest)
+	storesMu.Lock()
+	stores["plain"] = plainStore{}
+	storesMu.Unlock()
+
+	ctx := context.Background()
+	if _, _, err := GetWithGeneration(ctx, "plain://ns/key"); !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("GetWithGeneration on plain backend: err = %v, want ErrUnsupported", err)
+	}
+	if err := PutBytesIfGeneration(ctx, "plain://ns/key", nil, "", 0); !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("PutBytesIfGeneration on plain backend: err = %v, want ErrUnsupported", err)
+	}
+}

--- a/exp/storage/file.go
+++ b/exp/storage/file.go
@@ -12,14 +12,23 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 )
 
 const sidecarSuffix = ".meta.json"
 
-type fileStore struct{}
+// fileStore serializes writes with mu so generation reads and bumps are
+// atomic within one process. The generation itself persists in the
+// <path>.meta.json sidecar, but nothing locks the files themselves, so
+// conditional writes only guard against racing goroutines, not against a
+// second process — consistent with the backend's local-development role.
+type fileStore struct {
+	mu sync.Mutex
+}
 
 type sidecar struct {
 	ContentType string `json:"content_type,omitempty"`
+	Generation  int64  `json:"generation,omitempty"`
 }
 
 func pathFromURI(uri string) (string, error) {
@@ -48,7 +57,7 @@ func pathFromURI(uri string) (string, error) {
 	return p, nil
 }
 
-func (fileStore) Get(ctx context.Context, uri string) ([]byte, error) {
+func (f *fileStore) Get(ctx context.Context, uri string) ([]byte, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -63,7 +72,24 @@ func (fileStore) Get(ctx context.Context, uri string) ([]byte, error) {
 	return data, nil
 }
 
-func (fileStore) PutFile(ctx context.Context, uri, source string) error {
+func (f *fileStore) GetWithGeneration(ctx context.Context, uri string) ([]byte, int64, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, 0, err
+	}
+	p, err := pathFromURI(uri)
+	if err != nil {
+		return nil, 0, err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	data, err := os.ReadFile(p) // #nosec G304 -- path validated by pathFromURI
+	if err != nil {
+		return nil, 0, fmt.Errorf("storage: get %q: %w", uri, err)
+	}
+	return data, generationFor(p), nil
+}
+
+func (f *fileStore) PutFile(ctx context.Context, uri, source string) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -79,6 +105,9 @@ func (fileStore) PutFile(ctx context.Context, uri, source string) error {
 		return fmt.Errorf("storage: open source %q: %w", source, err)
 	}
 	defer func() { _ = src.Close() }()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	gen := f.generationLocked(p)
 	dst, err := os.Create(p) // #nosec G304 -- path validated by pathFromURI
 	if err != nil {
 		return fmt.Errorf("storage: create %q: %w", uri, err)
@@ -90,10 +119,13 @@ func (fileStore) PutFile(ctx context.Context, uri, source string) error {
 	if err := dst.Close(); err != nil {
 		return fmt.Errorf("storage: close %q: %w", uri, err)
 	}
+	if err := f.writeSidecarLocked(p, "", gen+1); err != nil {
+		return fmt.Errorf("storage: write sidecar for %q: %w", uri, err)
+	}
 	return nil
 }
 
-func (fileStore) PutBytes(ctx context.Context, uri string, data []byte, contentType string) error {
+func (f *fileStore) PutBytes(ctx context.Context, uri string, data []byte, contentType string) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -104,22 +136,19 @@ func (fileStore) PutBytes(ctx context.Context, uri string, data []byte, contentT
 	if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
 		return fmt.Errorf("storage: mkdir for %q: %w", uri, err)
 	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	gen := f.generationLocked(p)
 	if err := os.WriteFile(p, data, 0o600); err != nil {
 		return fmt.Errorf("storage: write %q: %w", uri, err)
 	}
-	if contentType != "" {
-		meta, err := json.Marshal(sidecar{ContentType: contentType})
-		if err != nil {
-			return fmt.Errorf("storage: marshal sidecar for %q: %w", uri, err)
-		}
-		if err := os.WriteFile(p+sidecarSuffix, meta, 0o600); err != nil {
-			return fmt.Errorf("storage: write sidecar for %q: %w", uri, err)
-		}
+	if err := f.writeSidecarLocked(p, contentType, gen+1); err != nil {
+		return fmt.Errorf("storage: write sidecar for %q: %w", uri, err)
 	}
 	return nil
 }
 
-func (fileStore) Delete(ctx context.Context, uri string) error {
+func (f *fileStore) PutBytesIfGeneration(ctx context.Context, uri string, data []byte, contentType string, ifGeneration int64) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -127,6 +156,35 @@ func (fileStore) Delete(ctx context.Context, uri string) error {
 	if err != nil {
 		return err
 	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	// A missing object has generation 0, so one comparison covers both the
+	// "must not exist yet" create and the "must still match" replace.
+	if f.generationLocked(p) != ifGeneration {
+		return fmt.Errorf("storage: put %q: %w", uri, ErrPreconditionFailed)
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
+		return fmt.Errorf("storage: mkdir for %q: %w", uri, err)
+	}
+	if err := os.WriteFile(p, data, 0o600); err != nil {
+		return fmt.Errorf("storage: write %q: %w", uri, err)
+	}
+	if err := f.writeSidecarLocked(p, contentType, ifGeneration+1); err != nil {
+		return fmt.Errorf("storage: write sidecar for %q: %w", uri, err)
+	}
+	return nil
+}
+
+func (f *fileStore) Delete(ctx context.Context, uri string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	p, err := pathFromURI(uri)
+	if err != nil {
+		return err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if err := os.Remove(p); err != nil {
 		return fmt.Errorf("storage: delete %q: %w", uri, err)
 	}
@@ -136,7 +194,7 @@ func (fileStore) Delete(ctx context.Context, uri string) error {
 	return nil
 }
 
-func (fileStore) List(ctx context.Context, uri string) ([]Object, error) {
+func (f *fileStore) List(ctx context.Context, uri string) ([]Object, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -159,11 +217,13 @@ func (fileStore) List(ctx context.Context, uri string) ([]Object, error) {
 		if err != nil {
 			return err
 		}
+		sc := readSidecar(p)
 		objs = append(objs, Object{
 			URI:         fileURIFor(p),
 			Size:        info.Size(),
-			ContentType: readSidecar(p),
+			ContentType: sc.ContentType,
 			Updated:     info.ModTime(),
+			Generation:  seededGeneration(sc.Generation),
 		})
 		return nil
 	})
@@ -187,16 +247,58 @@ func fileURIFor(p string) string {
 	return u.String()
 }
 
-func readSidecar(path string) string {
-	data, err := os.ReadFile(path + sidecarSuffix) // #nosec G304 -- path comes from filepath.WalkDir rooted at a validated prefix
+// generationLocked returns the current generation of the object at path:
+// the sidecar's recorded value, 1 for a pre-existing file with none, and 0
+// when the file does not exist. Callers must hold f.mu.
+func (f *fileStore) generationLocked(path string) int64 {
+	if _, err := os.Stat(path); err != nil {
+		return 0
+	}
+	return generationFor(path)
+}
+
+// generationFor returns the generation of an existing file: its sidecar's
+// recorded value, or 1 when the file predates generation tracking.
+func generationFor(path string) int64 {
+	return seededGeneration(readSidecar(path).Generation)
+}
+
+// seededGeneration maps an unrecorded generation to 1 so every existing
+// object reports a non-zero generation — 0 stays reserved for "the object
+// must not exist yet" in PutBytesIfGeneration.
+func seededGeneration(gen int64) int64 {
+	if gen == 0 {
+		return 1
+	}
+	return gen
+}
+
+// writeSidecarLocked records generation and contentType in the sidecar. An
+// empty contentType preserves the previously recorded one. Callers must
+// hold f.mu.
+func (f *fileStore) writeSidecarLocked(path, contentType string, generation int64) error {
+	sc := readSidecar(path)
+	sc.Generation = generation
+	if contentType != "" {
+		sc.ContentType = contentType
+	}
+	meta, err := json.Marshal(sc)
 	if err != nil {
-		return ""
+		return err
+	}
+	return os.WriteFile(path+sidecarSuffix, meta, 0o600)
+}
+
+func readSidecar(path string) sidecar {
+	data, err := os.ReadFile(path + sidecarSuffix) // #nosec G304 -- path comes from a validated URI or filepath.WalkDir rooted at a validated prefix
+	if err != nil {
+		return sidecar{}
 	}
 	var s sidecar
 	if err := json.Unmarshal(data, &s); err != nil {
-		return ""
+		return sidecar{}
 	}
-	return s.ContentType
+	return s
 }
 
-var _ Store = (*fileStore)(nil)
+var _ ConditionalStore = (*fileStore)(nil)

--- a/exp/storage/gcs.go
+++ b/exp/storage/gcs.go
@@ -6,12 +6,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
 	"sync"
 
 	gcssdk "cloud.google.com/go/storage"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iterator"
 )
 
@@ -115,6 +117,68 @@ func (g *gcsStore) PutBytes(ctx context.Context, uri string, data []byte, conten
 	return nil
 }
 
+func (g *gcsStore) GetWithGeneration(ctx context.Context, uri string) ([]byte, int64, error) {
+	bucket, key, err := splitGS(uri)
+	if err != nil {
+		return nil, 0, fmt.Errorf("storage: parse %q: %w", uri, err)
+	}
+	client, err := g.getClient(ctx)
+	if err != nil {
+		return nil, 0, fmt.Errorf("storage: gcs client: %w", err)
+	}
+	r, err := client.Bucket(bucket).Object(key).NewReader(ctx)
+	if err != nil {
+		if errors.Is(err, gcssdk.ErrObjectNotExist) {
+			return nil, 0, fmt.Errorf("storage: get %q: %w", uri, ErrNotExist)
+		}
+		return nil, 0, fmt.Errorf("storage: get %q: %w", uri, err)
+	}
+	defer func() { _ = r.Close() }()
+	buf := bytes.NewBuffer(nil)
+	if _, err := io.Copy(buf, r); err != nil {
+		return nil, 0, fmt.Errorf("storage: read %q: %w", uri, err)
+	}
+	return buf.Bytes(), r.Attrs.Generation, nil
+}
+
+func (g *gcsStore) PutBytesIfGeneration(ctx context.Context, uri string, data []byte, contentType string, ifGeneration int64) error {
+	bucket, key, err := splitGS(uri)
+	if err != nil {
+		return fmt.Errorf("storage: parse %q: %w", uri, err)
+	}
+	client, err := g.getClient(ctx)
+	if err != nil {
+		return fmt.Errorf("storage: gcs client: %w", err)
+	}
+	cond := gcssdk.Conditions{GenerationMatch: ifGeneration}
+	if ifGeneration == 0 {
+		cond = gcssdk.Conditions{DoesNotExist: true}
+	}
+	w := client.Bucket(bucket).Object(key).If(cond).NewWriter(ctx)
+	w.ContentType = contentType
+	if _, err := io.Copy(w, bytes.NewReader(data)); err != nil {
+		_ = w.Close()
+		if isPreconditionFailed(err) {
+			return fmt.Errorf("storage: put %q: %w", uri, ErrPreconditionFailed)
+		}
+		return fmt.Errorf("storage: write %q: %w", uri, err)
+	}
+	if err := w.Close(); err != nil {
+		if isPreconditionFailed(err) {
+			return fmt.Errorf("storage: put %q: %w", uri, ErrPreconditionFailed)
+		}
+		return fmt.Errorf("storage: close %q: %w", uri, err)
+	}
+	return nil
+}
+
+// isPreconditionFailed reports whether err is GCS's HTTP 412 response — the
+// generation precondition losing the race.
+func isPreconditionFailed(err error) bool {
+	var apiErr *googleapi.Error
+	return errors.As(err, &apiErr) && apiErr.Code == http.StatusPreconditionFailed
+}
+
 func (g *gcsStore) Delete(ctx context.Context, uri string) error {
 	bucket, key, err := splitGS(uri)
 	if err != nil {
@@ -168,4 +232,4 @@ func (g *gcsStore) List(ctx context.Context, uri string) ([]Object, error) {
 	return objs, nil
 }
 
-var _ Store = (*gcsStore)(nil)
+var _ ConditionalStore = (*gcsStore)(nil)

--- a/exp/storage/mem.go
+++ b/exp/storage/mem.go
@@ -25,6 +25,11 @@ type memObject struct {
 	data        []byte
 	contentType string
 	updated     time.Time
+
+	// generation counts writes to this key, starting at 1. Every put —
+	// conditional or not — bumps it, so an unconditional PutBytes
+	// invalidates any generation a conditional writer is holding.
+	generation int64
 }
 
 func newMemStore() *memStore {
@@ -77,7 +82,7 @@ func (m *memStore) PutFile(ctx context.Context, uri, source string) error {
 		return fmt.Errorf("storage: open source %q: %w", source, err)
 	}
 	m.mu.Lock()
-	m.objects[k] = memObject{data: data, updated: time.Now()}
+	m.objects[k] = memObject{data: data, updated: time.Now(), generation: m.objects[k].generation + 1}
 	m.mu.Unlock()
 	return nil
 }
@@ -93,8 +98,49 @@ func (m *memStore) PutBytes(ctx context.Context, uri string, data []byte, conten
 	stored := make([]byte, len(data))
 	copy(stored, data)
 	m.mu.Lock()
-	m.objects[k] = memObject{data: stored, contentType: contentType, updated: time.Now()}
+	m.objects[k] = memObject{data: stored, contentType: contentType, updated: time.Now(), generation: m.objects[k].generation + 1}
 	m.mu.Unlock()
+	return nil
+}
+
+func (m *memStore) GetWithGeneration(ctx context.Context, uri string) ([]byte, int64, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, 0, err
+	}
+	k, err := memKey(uri)
+	if err != nil {
+		return nil, 0, err
+	}
+	m.mu.RLock()
+	obj, ok := m.objects[k]
+	m.mu.RUnlock()
+	if !ok {
+		return nil, 0, fmt.Errorf("storage: get %q: %w", uri, ErrNotExist)
+	}
+	out := make([]byte, len(obj.data))
+	copy(out, obj.data)
+	return out, obj.generation, nil
+}
+
+func (m *memStore) PutBytesIfGeneration(ctx context.Context, uri string, data []byte, contentType string, ifGeneration int64) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	k, err := memKey(uri)
+	if err != nil {
+		return err
+	}
+	stored := make([]byte, len(data))
+	copy(stored, data)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// A missing object has generation 0, so one comparison covers both the
+	// "must not exist yet" create and the "must still match" replace.
+	cur := m.objects[k].generation
+	if cur != ifGeneration {
+		return fmt.Errorf("storage: put %q: %w", uri, ErrPreconditionFailed)
+	}
+	m.objects[k] = memObject{data: stored, contentType: contentType, updated: time.Now(), generation: cur + 1}
 	return nil
 }
 
@@ -135,10 +181,11 @@ func (m *memStore) List(ctx context.Context, uri string) ([]Object, error) {
 			Size:        int64(len(obj.data)),
 			ContentType: obj.contentType,
 			Updated:     obj.updated,
+			Generation:  obj.generation,
 		})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].URI < out[j].URI })
 	return out, nil
 }
 
-var _ Store = (*memStore)(nil)
+var _ ConditionalStore = (*memStore)(nil)

--- a/exp/storage/storage.go
+++ b/exp/storage/storage.go
@@ -30,10 +30,11 @@ type Object struct {
 	ContentType string
 	Updated     time.Time
 
-	// Generation and Metageneration are GCS-specific identifiers used for
-	// optimistic concurrency. Generation changes on every object replacement;
-	// Metageneration changes on every metadata update. Both are zero on the
-	// file:// backend.
+	// Generation and Metageneration are identifiers used for optimistic
+	// concurrency. Generation changes on every object replacement and is
+	// reported by all three backends; it matches what GetWithGeneration
+	// returns for the same object. Metageneration changes on every metadata
+	// update and is zero outside the gs:// backend.
 	Generation     int64
 	Metageneration int64
 }
@@ -52,7 +53,8 @@ type Store interface {
 
 	// PutBytes writes data to uri. On gs:// URIs, contentType becomes the
 	// object's Content-Type metadata. On file:// URIs, a <path>.meta.json
-	// sidecar records it; an empty contentType skips the sidecar write.
+	// sidecar records the content type and the object's generation; an
+	// empty contentType preserves any previously recorded content type.
 	PutBytes(ctx context.Context, uri string, data []byte, contentType string) error
 
 	// Delete removes the object at uri. On file:// URIs, an adjacent
@@ -68,6 +70,36 @@ type Store interface {
 	List(ctx context.Context, uri string) ([]Object, error)
 }
 
+// ConditionalStore extends Store with generation-preconditioned reads and
+// writes for optimistic concurrency. All three built-in backends implement
+// it; the extension interface keeps Store small so external implementations
+// (test doubles, wrappers) keep compiling. Callers who work through URIs
+// should use the package-level GetWithGeneration and PutBytesIfGeneration,
+// which type-assert and return an error wrapping ErrUnsupported when the
+// backend lacks conditional support.
+type ConditionalStore interface {
+	Store
+
+	// GetWithGeneration reads the entire object at uri into memory and
+	// returns its current generation for use as PutBytesIfGeneration's
+	// ifGeneration. Returns an error wrapping ErrNotExist when the object
+	// does not exist.
+	GetWithGeneration(ctx context.Context, uri string) (data []byte, generation int64, err error)
+
+	// PutBytesIfGeneration writes data to uri only if the object's current
+	// generation matches ifGeneration; ifGeneration 0 requires that the
+	// object not exist yet (create). Returns an error wrapping
+	// ErrPreconditionFailed when the precondition does not hold, leaving
+	// the stored object untouched. contentType is handled as in PutBytes.
+	//
+	// Generations are opaque: obtain them from GetWithGeneration (or List)
+	// and compare only for equality. gs:// uses real GCS preconditions.
+	// file:// persists a counter in the <path>.meta.json sidecar but only
+	// serializes writers within one process; mem:// counts in memory. Both
+	// are honest for their single-process dev and test roles only.
+	PutBytesIfGeneration(ctx context.Context, uri string, data []byte, contentType string, ifGeneration int64) error
+}
+
 var (
 	// ErrUnsupportedScheme is returned by For when the URI's scheme has no backend.
 	ErrUnsupportedScheme = errors.New("storage: unsupported scheme")
@@ -81,6 +113,18 @@ var (
 	// aliases io/fs.ErrNotExist so callers can use errors.Is with either
 	// sentinel without importing backend-specific error types.
 	ErrNotExist = fs.ErrNotExist
+
+	// ErrPreconditionFailed indicates that a conditional write lost the
+	// race: the object's generation no longer matched the caller's
+	// ifGeneration. Callers typically re-read with GetWithGeneration and
+	// retry.
+	ErrPreconditionFailed = errors.New("storage: precondition failed")
+
+	// ErrUnsupported indicates that the backend does not implement the
+	// requested optional capability, such as conditional writes. It aliases
+	// errors.ErrUnsupported so callers can use errors.Is with either
+	// sentinel.
+	ErrUnsupported = errors.ErrUnsupported
 
 	storesMu sync.RWMutex
 	stores   = map[string]Store{}
@@ -143,6 +187,38 @@ func PutBytes(ctx context.Context, uri string, data []byte, contentType string) 
 		return err
 	}
 	return s.PutBytes(ctx, uri, data, contentType)
+}
+
+// GetWithGeneration reads the object at uri and returns its current
+// generation for use with PutBytesIfGeneration. Returns an error wrapping
+// ErrUnsupported when the URI's backend does not implement ConditionalStore.
+func GetWithGeneration(ctx context.Context, uri string) ([]byte, int64, error) {
+	s, err := For(uri)
+	if err != nil {
+		return nil, 0, err
+	}
+	cs, ok := s.(ConditionalStore)
+	if !ok {
+		return nil, 0, fmt.Errorf("storage: get with generation %q: conditional reads: %w", uri, ErrUnsupported)
+	}
+	return cs.GetWithGeneration(ctx, uri)
+}
+
+// PutBytesIfGeneration writes data to uri only if the object's generation
+// still matches ifGeneration (0 = the object must not exist yet). Returns an
+// error wrapping ErrPreconditionFailed when another writer got there first,
+// and an error wrapping ErrUnsupported when the URI's backend does not
+// implement ConditionalStore.
+func PutBytesIfGeneration(ctx context.Context, uri string, data []byte, contentType string, ifGeneration int64) error {
+	s, err := For(uri)
+	if err != nil {
+		return err
+	}
+	cs, ok := s.(ConditionalStore)
+	if !ok {
+		return fmt.Errorf("storage: put %q: conditional writes: %w", uri, ErrUnsupported)
+	}
+	return cs.PutBytesIfGeneration(ctx, uri, data, contentType, ifGeneration)
 }
 
 // Delete removes the object at uri.


### PR DESCRIPTION
## Motivation

querystory/qsi-automation's `dale` service needed optimistically locked writes for its `manifest.json` catalog object. `exp/storage` only exposes unconditional `PutBytes`, so dale had to bypass the abstraction and talk to `cloud.google.com/go/storage` directly for `if-generation-match` preconditions — keeping a parallel per-scheme implementation (real preconditions on `gs://`, a process-local counter for `file://` and `mem://`). That duplication belongs upstream, behind the same URI-addressable interface.

## API surface

```go
// Sentinels
var ErrPreconditionFailed = errors.New("storage: precondition failed")
var ErrUnsupported = errors.ErrUnsupported // aliased, like ErrNotExist aliases fs.ErrNotExist

// Extension interface, implemented by all three built-in backends
type ConditionalStore interface {
    Store
    GetWithGeneration(ctx context.Context, uri string) (data []byte, generation int64, err error)
    PutBytesIfGeneration(ctx context.Context, uri string, data []byte, contentType string, ifGeneration int64) error
}

// Package-level helpers, mirroring Get/PutBytes
func GetWithGeneration(ctx context.Context, uri string) ([]byte, int64, error)
func PutBytesIfGeneration(ctx context.Context, uri string, data []byte, contentType string, ifGeneration int64) error
```

`ifGeneration == 0` means "the object must not exist yet" (create). A lost race returns an error wrapping `ErrPreconditionFailed`; a missing object on read wraps `ErrNotExist`, consistent with `Get`.

## Interface placement

The new methods live on a separate `ConditionalStore` extension interface rather than on `Store`. The scheme registry is closed (no external backend registration), but downstream code can still implement `Store` for test doubles and wrappers — widening `Store` would break every one of them on upgrade. The extension-interface pattern (stdlib `io.ReaderFrom`, `fs.ReadDirFS`) keeps `Store` small, while the package-level helpers preserve the "switch backends by changing a URI" ergonomics: they type-assert and return an error wrapping `ErrUnsupported` when a backend lacks conditional support.

## Per-backend semantics

- **gs://** — real GCS preconditions: `Conditions{GenerationMatch: n}` / `Conditions{DoesNotExist: true}` on the object writer; the HTTP 412 response maps to `ErrPreconditionFailed`. Reuses the existing memoized client.
- **file://** — the generation persists in the existing `<path>.meta.json` sidecar (now always written, so it survives restarts); a per-store mutex serializes writers within one process. A pre-existing file without a sidecar reports generation 1, so a stale gen-0 create cannot clobber it. Cross-process writers are not locked out — consistent with the backend's local-development role, and documented.
- **mem://** — a per-object counter guarded by the existing mutex.

On every backend, unconditional `PutBytes`/`PutFile` also bump the generation, so an outstanding conditional writer detects the interleaved write and loses. `Object.Generation` from `List` now matches `GetWithGeneration` on all three backends (previously gs://-only).

## Test plan

All of the below run against all three backends (gs:// via the existing fake-gcs harness):

- [x] create with `ifGeneration` 0 succeeds; create-over-existing with 0 fails with `ErrPreconditionFailed`
- [x] read-back returns a non-zero generation; write with the matching generation succeeds and changes it
- [x] stale-generation write fails with `ErrPreconditionFailed` and does not clobber content
- [x] unconditional `PutBytes` invalidates an outstanding generation
- [x] missing object: `GetWithGeneration` wraps `ErrNotExist`
- [x] read-modify-write retry loop converges after one simulated conflict
- [x] `List` generation matches `GetWithGeneration`
- [x] file://: pre-existing file without a sidecar seeds generation 1
- [x] 412 → `ErrPreconditionFailed` mapping pinned independent of the fake server
- [x] package helpers round-trip; non-conditional backend returns `ErrUnsupported`
- [x] `go test -race ./...`, `go vet ./...`, `gofmt -s -l .`, `go build -race ./...`, `go mod tidy` diff-clean, golangci-lint v2.11.4: 0 issues
